### PR TITLE
add .mailmap file to cleanup names in commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+Edwin Young <edwin@bathysphere.org>
+Edwin Young <edwin@bathysphere.org> catenary <catenary@users.sourceforge.net>
+Edwin Young <edwin@bathysphere.org> edwin young <catenary@edwins-MacBook-Air.local>
+Edwin Young <edwin@bathysphere.org> Tim Whidbey <catenary@bathysphere.org>
+Cameron Garnham <me@da2ce7.com>
+Richard Mant <dx-mon@users.sourceforge.net> Richard Mant <dx-mon@DX-TOP.(none)>
+Richard Mant <dx-mon@users.sourceforge.net> dx-mon <dx-mon@users.sourceforge.net>
+Jerry James <loganjerry@gmail.com>
+Chris Mayo <aklhfex@gmail.com>
+James Hiew <james@hiew.net>
+Jose Bailo <jmbailo@gmail.com>
+Alberto Gonzalez <mindhells@gmail.com>
+Guanchor Ojeda Hernández <guanchor@gmail.com>


### PR DESCRIPTION
In this commit I have created a mailmap taken from the command:

```
( git log  --format="%aN <%aE>" --reverse ; git log  --format="%cN <%cE>" --reverse ) | perl -e 'my %dedupe; while (<STDIN>) { print unless $dedupe{$_}++}'
```

Please review the `.mailmap` file included in this pull request.