### PR TITLE
Add -std=c++17 building flag and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,18 @@ Optionally, install tox and test with all supported Python versions by running:
 tox
 
 On MacOS you might find an error regarding the number of opened files, you can increase the system limit with `ulimit -Sn 10000`
+
+Linting
+=======
+
+Pylint is being used to detect code that doesn't follow the [PEP8 style](https://www.python.org/dev/peps/pep-0008/) guide and potentially erroneus code in Python.
+You can run it in two ways:
+ - Directly (firstly you should install pylint throw pip3):
+```
+$ sudo pip3 install pylint
+$ ./bin/pylint.sh
+```
+ - Using docker (same enviorment than pipeline):
+```
+$ ./docker/bin/run_lint.sh
+```

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ defines = [
 ]
 
 libraries = ['stdc++']
-extra_compile_args = ['-Wall', '-O0'] + png_flags
+extra_compile_args = ['-Wall', '-O0', '-std=c++17'] + png_flags
 define_macros = defines + extra_macros
 
 module_fract4dc = Extension(


### PR DESCRIPTION
There is no minimal C++ compiler version required and C++98 std is being used as default std in GCC versions prior to 6.1, so a new flag is added in the building phase to allow to support newer C++ language standards as used in #85.

Update the readme with info about pylint (more info #66).