### PR TITLE
Fix #90

### DIFF
--- a/fract4d_compiler/codegen.py
+++ b/fract4d_compiler/codegen.py
@@ -3,6 +3,7 @@
 # Generate C code from a linearized IR trace
 
 import re
+import os
 
 from . import absyn, fracttypes, ir, optimize
 from .fracttypes import Bool, Int, Float, Complex, Hyper, Color, IntArray, FloatArray, ComplexArray, VoidArray
@@ -61,8 +62,8 @@ class T:
 #include <stdlib.h>
 #include <math.h>
 
-%(fract_stdlib)s
-%(pf)s
+#include "fract_stdlib.h"
+#include "pf.h"
 
 typedef struct {
     pf_obj parent;
@@ -238,10 +239,6 @@ pf_obj *pf_new()
 
 %(main_inserts)s
 '''
-        # we insert pf.h so C compiler doesn't have to find it
-        # this needs to be updated each time pf.h changes
-        self.pf_header = open('fract4d/c/pf.h').read()
-        self.fract_stdlib_header = open('fract4d/c/fract_stdlib.h').read()
 
     def emit_binop(self, op, srcs, type):
         dst = self.newTemp(type)
@@ -480,8 +477,6 @@ pf_obj *pf_new()
 
     def output_c(self, t, inserts={}, output_template=None):
         inserts["bailout_var"] = self.get_bailout_var(t)
-        inserts["pf"] = self.pf_header
-        inserts["fract_stdlib"] = self.fract_stdlib_header
         inserts["dca_init"] = "%d" % self.is_direct()
 
         if self.is_direct():

--- a/fract4d_compiler/codegen.py
+++ b/fract4d_compiler/codegen.py
@@ -3,7 +3,6 @@
 # Generate C code from a linearized IR trace
 
 import re
-import os
 
 from . import absyn, fracttypes, ir, optimize
 from .fracttypes import Bool, Int, Float, Complex, Hyper, Color, IntArray, FloatArray, ComplexArray, VoidArray

--- a/fract4d_compiler/fc.py
+++ b/fract4d_compiler/fc.py
@@ -31,6 +31,7 @@ import hashlib
 import re
 import copy
 
+import fract4d
 from fract4d import gradient, fractconfig
 from . import (fractparser, fractlexer, translate, codegen, fracttypes, absyn,
                preprocessor, cache)
@@ -144,6 +145,8 @@ class Compiler:
         self.path_lists = [[], [], [], []]
 
         self.compiler_name = "gcc"
+
+        self.include_path = "-I%s/c/" % os.path.dirname(fract4d.__file__)
         self.flags = "-fPIC -DPIC -g -O3 -shared"
         self.output_flag = "-o "
         self.libs = "-lm"
@@ -418,8 +421,8 @@ class Compiler:
         f.close()
 
         # -march=i686 for 10% speed gain
-        cmd = "%s \"%s\" %s %s\"%s\"" % \
-              (self.compiler_name, cfile, self.flags, self.output_flag, outputfile)
+        cmd = "%s \"%s\" %s %s %s\"%s\"" % \
+              (self.compiler_name, cfile, self.flags, self.include_path, self.output_flag, outputfile)
         cmd += " %s" % self.libs
 
         (status, output) = subprocess.getstatusoutput(cmd)

--- a/fract4d_compiler/tests/test_codegen.py
+++ b/fract4d_compiler/tests/test_codegen.py
@@ -244,10 +244,10 @@ int main()
         oFileName = str(Path(cFile.name).with_suffix(".so"))
         import sys
         if sys.platform[:6] == "darwin":
-            cmd = "gcc -Wall -fPIC -DPIC -shared %s -o %s -lm -flat_namespace -undefined suppress" % (
+            cmd = "gcc -Wall -fPIC -DPIC -Ifract4d/c -shared %s -o %s -lm -flat_namespace -undefined suppress" % (
                 cFile.name, oFileName)
         else:
-            cmd = "gcc -Wall -fPIC -DPIC -shared %s -o %s -lm" % (
+            cmd = "gcc -Wall -fPIC -DPIC -Ifract4d/c -shared %s -o %s -lm" % (
                 cFile.name, oFileName)
         status, output = subprocess.getstatusoutput(cmd)
         self.assertEqual(status, 0, "C error:\n%s\nProgram:\n%s\n" %
@@ -299,20 +299,6 @@ int main()
         self.assertEqual(1, len(self.codegen.out))
         move = self.codegen.out[0]
         # print move.format()
-
-    def testPFHeader(self):
-        'Check inline copy of pf.h is up-to-date'
-        pfh = open('fract4d/c/pf.h')
-        header_contents = pfh.read()
-        pfh.close()
-        self.assertEqual(header_contents, self.codegen.pf_header)
-
-    def testStdlibHeader(self):
-        'Check inline copy of fract_stdlib.h is up-to-date'
-        header = open('fract4d/c/fract_stdlib.h')
-        header_contents = header.read()
-        header.close()
-        self.assertEqual(header_contents, self.codegen.fract_stdlib_header)
 
     def testMatching(self):
         'test tree matching works'

--- a/setup.py
+++ b/setup.py
@@ -127,8 +127,7 @@ module_fract4dc = Extension(
     libraries=libraries + jpg_libs,
     extra_compile_args=extra_compile_args,
     extra_link_args=png_libs,
-    define_macros=define_macros,
-    #undef_macros = [ 'NDEBUG'],
+    define_macros=define_macros
 )
 
 module_cmap = Extension(
@@ -175,7 +174,10 @@ and includes a Fractint-compatible parser for your own fractal formulas.''',
     keywords="edwin@bathysphere.org",
     url='http://github.com/edyoung/gnofract4d/',
     packages=['fract4d_compiler', 'fract4d', 'fract4dgui'],
-    package_data={'fract4dgui': ['shortcuts-gnofract4d.ui', 'ui.xml']},
+    package_data={
+        'fract4dgui': ['shortcuts-gnofract4d.ui', 'ui.xml'],
+        'fract4d': ['c/pf.h', 'c/fract_stdlib.h']
+    },
     ext_modules=modules,
     scripts=['gnofract4d'],
     data_files=[
@@ -232,7 +234,7 @@ and includes a Fractint-compatible parser for your own fractal formulas.''',
         # MIME type registration
         ('share/mime/packages', ['gnofract4d-mime.xml']),
         # doc files
-        ('share/doc/gnofract4d/', ['LICENSE', 'README.md']),
+        ('share/doc/gnofract4d/', ['LICENSE', 'README.md'])
     ],
     cmdclass={
         "install_lib": my_install_lib.my_install_lib


### PR DESCRIPTION
At runtime the C compiler needs the contents of pf.h and fract_stdlib.h. Originally I did this by including the contents of those files in here-strings in the python module. During refactor this was changed to load them from a subdir. But we weren't installing those files, and we weren't looking for them in the right place after installation, so that failed.

This installs the files as part of fract4d module and has the C compiler doing the includes rather than doing it ourselves.