### PR TITLE
Allow documentation to be built in a non-graphical environment

### DIFF
--- a/createdocs.py
+++ b/createdocs.py
@@ -20,7 +20,7 @@ def create_stdlib_docs():
 
         # create list of mouse and GUI commands
         import fract4dgui.createdocs
-        fract4dgui.createdocs.main("doc/gnofract4d-manual/C/commands.xml")
+        fract4dgui.createdocs.main("doc/gnofract4d-manual/C/commands.xml")  # pylint: disable=no-value-for-parameter
 
         # create HTML version of docs for them as don't have yelp
         os.chdir("doc/gnofract4d-manual/C")

--- a/fract4dgui/createdocs.py
+++ b/fract4dgui/createdocs.py
@@ -94,11 +94,14 @@ class CommandPrinter:
         print('</sect2>', file=self.f)
 
 
-# @patch('fract4dgui.main_window.MainWindow.__init__')
-def main(outfile):
+# MainWindow.__init__() is disabled to avoid initialising GTK,
+# allowing the documentation to be created in a non-graphical environment
+@patch('fract4dgui.main_window.MainWindow.__init__')
+def main(outfile, mw_init):
     out = open(outfile, "w")
     printer = CommandPrinter(out)
 
+    mw_init.return_value = None
     userConfig = fractconfig.userConfig()
     mw = main_window.MainWindow(userConfig)
 
@@ -136,4 +139,4 @@ def main(outfile):
 
 
 if __name__ == '__main__':
-    main('../doc/gnofract4d-manual/C/commands.xml')
+    main('../doc/gnofract4d-manual/C/commands.xml')  # pylint: disable=no-value-for-parameter

--- a/fract4dgui/createdocs.py
+++ b/fract4dgui/createdocs.py
@@ -5,12 +5,10 @@
 
 import os
 import re
-import gi
-
-from xml.sax.saxutils import escape
 from unittest.mock import patch
-from fract4d import fractconfig
+from xml.sax.saxutils import escape
 
+from fract4d import fractconfig
 from . import main_window
 
 import gettext


### PR DESCRIPTION
These are needed when building the package on Gentoo. I've added a comment to the code.
