### PR TITLE
Enable pytest coverage checking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+	*/tests/*
+	fract4d_compiler/lex.py
+	fract4d_compiler/yacc.py

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.so
 *~
 #*
+.coverage
 MANIFEST
 token
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ envlist = py3{5,6,7,8}
 deps =
     pygobject
     pytest
+    pytest-cov
 
 commands =
-    pytest {posargs: fract4d fract4dgui fract4d_compiler test.py}
+    pytest {posargs: --cov=fract4d --cov=fract4dgui --cov=fract4d_compiler fract4d fract4dgui fract4d_compiler test.py}
 
 passenv = DISPLAY XAUTHORITY HOME


### PR DESCRIPTION
Test coverage is quite good, 79% with a lot of files over 90%, the overall number brought down by a few specific  files.

I suggest enabling reporting to keep it high.

I like the Coveralls service which can be hooked up to GitHub and provide browesable results and noitfications that can be used as PR checks https://coveralls.io/.
