### PR TITLE
Exclude parsetab and lextab from pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -9,6 +9,8 @@ enable=E,
   bare-except,
   unused-import
 
+ignore=parsetab.py,lextab.py
+
 [REPORTS]
 score=no
 


### PR DESCRIPTION
As pylint is now part of the travis scripts:
```yaml
script:
  - ./bin/pylint.sh || travis_terminate 1;
  - tox
```
We need to exclude the automatically generated files `lextab.py` and `parsetab.py` to pass the tests because they do not conform to the rules being checked.
Those files were removed from the repo in #55 by mistake (preventing the application to work when installed) and reintroduced in  #93 to fix that problem.

NOTE: At this moment travis is not working on this repo, see #92.