### PR TITLE
Arbitrary precision formula experiment

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -153,3 +153,12 @@ Execute:
 examples/cpp/custom_formula.sh
 ```
 Then you should see a new file under `examples/output`.
+
+### Creating a simple mandelbrot using a custom formula with MPFR
+In this example we did an experiment using [mpfr library](https://www.mpfr.org/). We replaced the double types in the formula from the previos example with a custom type with operator overloading using a multiple precision support from mpfr.
+Of course this is not changing much the final result as for that we'd need to change the fract4dc engine (sources under /model) to support multiple precision. It's just an experiment about one possible approach to tackle the arbitrary precision support which would also need to change the compiler, among many other parts of the program.
+Execute:
+```
+examples/cpp/mp_mandelbrot.sh
+```
+Then you should see a new file under `examples/output`.

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -3,6 +3,12 @@ project(simple_mandelbrot)
 
 set(CMAKE_CXX_STANDARD 17)
 
+# add some debug information: elapsed time and compiler information
+set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+set(CMAKE_VERBOSE_MAKEFILE on)
+message("Compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/model)
 

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -45,6 +45,27 @@ set_target_properties(fract_stdlib PROPERTIES SUFFIX ".so")
 get_filename_component(FORMULA_FILE $ENV{formula_source} NAME)
 
 add_library(formula SHARED
-    ${PROJECT_SOURCE_DIR}/${FORMULA_FILE})
+        ${PROJECT_SOURCE_DIR}/${FORMULA_FILE})
+
+if("$ENV{gmp_support}" STREQUAL "1")
+    message("gmp support enabled")
+
+    # https://github.com/symengine/symengine/blob/master/cmake/LibFindMacros.cmake
+    find_library(MPFR_LIBRARIES NAMES mpfr)
+    find_library(GMP_LIBRARIES NAMES gmpxx)
+
+    find_path(MPFR_INCLUDES NAMES mpfr.h)
+    find_path(GMP_INCLUDE_DIR NAMES gmpxx.h)
+
+    include_directories(${GMP_INCLUDE_DIR})
+    target_link_libraries(formula ${GMP_LIBRARIES})
+    include_directories(${MPFR_INCLUDES})
+    target_link_libraries(formula ${MPFR_LIBRARIES})
+
+else()
+    message("gmp support disabled")
+
+endif()
+
 set_target_properties(formula PROPERTIES SUFFIX ".so")
 set_target_properties(formula PROPERTIES PREFIX "")

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -42,7 +42,9 @@ set_target_properties(fract_stdlib PROPERTIES SUFFIX ".so")
 
 # FORMULA LIB
 
+get_filename_component(FORMULA_FILE $ENV{formula_source} NAME)
+
 add_library(formula SHARED
-    ${PROJECT_SOURCE_DIR}/formula.c)
+    ${PROJECT_SOURCE_DIR}/${FORMULA_FILE})
 set_target_properties(formula PROPERTIES SUFFIX ".so")
 set_target_properties(formula PROPERTIES PREFIX "")

--- a/examples/cpp/Dockerfile
+++ b/examples/cpp/Dockerfile
@@ -15,7 +15,9 @@ COPY examples/cpp/${main_source} ./main.cpp
 COPY examples/cpp/CMakeLists.txt ./
 COPY fract4d/c/fract_stdlib.cpp fract4d/c/fract_stdlib.h fract4d/c/pf.h  ./
 COPY fract4d/c/model/ ./model
-COPY ${formula_source} ./formula.c
+COPY ${formula_source} ./
+
+ENV formula_source=$formula_source
 
 RUN cmake . && make
 

--- a/examples/cpp/Dockerfile
+++ b/examples/cpp/Dockerfile
@@ -5,11 +5,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
 	apt-get install -y build-essential git cmake autoconf libtool pkg-config libpng-dev libjpeg-dev
+RUN apt-get install -y libmpfr-dev libgmp-dev
 
 WORKDIR /src
 
 ARG main_source
 ARG formula_source
+ARG gmp_support
 
 COPY examples/cpp/${main_source} ./main.cpp
 COPY examples/cpp/CMakeLists.txt ./
@@ -18,6 +20,8 @@ COPY fract4d/c/model/ ./model
 COPY ${formula_source} ./
 
 ENV formula_source=$formula_source
+ENV gmp_support=$gmp_support
+COPY examples/cpp/mp_double.h ./mp_double.h
 
 RUN cmake . && make
 

--- a/examples/cpp/mp_double.h
+++ b/examples/cpp/mp_double.h
@@ -3,32 +3,36 @@
 
 #include <mpfr.h>
 
-class MpDouble {
-    private:
+class MpDouble final {
     mpfr_t value;
-    public:
+public:
+
     // copy constructor
-    MpDouble(const MpDouble &original) {
+    MpDouble(const MpDouble &original) noexcept {
         mpfr_init(value);
         mpfr_set(value, original.value, MPFR_RNDN);
     }
     // move constructor
-    MpDouble(MpDouble &&original) {
+    MpDouble(MpDouble &&original) noexcept {
         mpfr_init(value); // this is needed to keep original is a safe state for destruction
-        mpfr_swap(value, original.value);
+        swap(original);
     }
     // implicit constructor
-    MpDouble(const double literal) {
+    MpDouble(const double literal) noexcept {
         mpfr_init(value);
         mpfr_set_d(value, literal, MPFR_RNDN);
     }
     // explicit constructors
-    explicit MpDouble(const char *literal) {
+    explicit MpDouble(const char *literal) noexcept {
         mpfr_init(value);
         mpfr_set_str(value, literal, 10, MPFR_RNDN);
     }
-    explicit MpDouble(mpfr_t val) {
+    explicit MpDouble(mpfr_t val) noexcept {
         mpfr_swap(value, val);
+    }
+    // swap
+    inline void swap(MpDouble &other) noexcept {
+        mpfr_swap(value, other.value);
     }
     // destructor
     ~MpDouble() {
@@ -49,49 +53,33 @@ class MpDouble {
     }
 
     // assignment operation
-    MpDouble &operator=(const MpDouble &other) {
+    MpDouble &operator=(const MpDouble &other) noexcept {
         if(this == &other) return *this;
         mpfr_set(value, other.value, MPFR_RNDN);
         return *this;
     }
     // move assignment operation
-    MpDouble &operator=(MpDouble &&other) {
+    MpDouble &operator=(MpDouble &&other) noexcept {
         if(this == &other) return *this;
-        mpfr_swap(this->value, other.value);
+        swap(other);
         return *this;
     }
 
     // arithmetic operations
     MpDouble &operator+=(const MpDouble &other) {
-        mpfr_t result;
-        mpfr_init(result);
-        mpfr_add(result, value, other.value, MPFR_RNDN);
-        mpfr_swap(value, result);
-        mpfr_clear(result);
+        mpfr_add(value, value, other.value, MPFR_RNDN);
         return *this;
     }
     MpDouble &operator-=(const MpDouble &other) {
-        mpfr_t result;
-        mpfr_init(result);
-        mpfr_sub(result, value, other.value, MPFR_RNDN);
-        mpfr_swap(value, result);
-        mpfr_clear(result);
+        mpfr_sub(value, value, other.value, MPFR_RNDN);
         return *this;
     }
     MpDouble &operator/=(const MpDouble &other) {
-        mpfr_t result;
-        mpfr_init(result);
-        mpfr_div(result, value, other.value, MPFR_RNDN);
-        mpfr_swap(value, result);
-        mpfr_clear(result);
+        mpfr_div(value, value, other.value, MPFR_RNDN);
         return *this;
     }
     MpDouble &operator*=(const MpDouble &other) {
-        mpfr_t result;
-        mpfr_init(result);
-        mpfr_mul(result, value, other.value, MPFR_RNDN);
-        mpfr_swap(value, result);
-        mpfr_clear(result);
+        mpfr_mul(value, value, other.value, MPFR_RNDN);
         return *this;
     }
 
@@ -107,7 +95,12 @@ class MpDouble {
     friend bool operator!=(const MpDouble &a, const MpDouble &b);
     friend bool operator==(const MpDouble &a, const MpDouble &b);
 
+    friend void swap(MpDouble &a, MpDouble &b);
 };
+
+void swap(MpDouble &a, MpDouble &b) {
+    a.swap(b);
+}
 
 MpDouble operator+(const MpDouble &a, const MpDouble &b) {
     mpfr_t result;
@@ -124,7 +117,6 @@ MpDouble operator-(const MpDouble &a, const MpDouble &b) {
 }
 
 MpDouble operator/(const MpDouble &a, const MpDouble &b) {
-
     mpfr_t result;
     mpfr_init(result);
     mpfr_div(result, a.value, b.value, MPFR_RNDN);

--- a/examples/cpp/mp_double.h
+++ b/examples/cpp/mp_double.h
@@ -1,0 +1,163 @@
+#include <utility>
+#include <cstdio>
+
+#include <mpfr.h>
+
+class MpDouble {
+    private:
+    mpfr_t value;
+    public:
+    // copy constructor
+    MpDouble(const MpDouble &original) {
+        mpfr_init(value);
+        mpfr_set(value, original.value, MPFR_RNDN);
+    }
+    // move constructor
+    MpDouble(MpDouble &&original) {
+        mpfr_init(value); // this is needed to keep original is a safe state for destruction
+        mpfr_swap(value, original.value);
+    }
+    // implicit constructor
+    MpDouble(const double literal) {
+        mpfr_init(value);
+        mpfr_set_d(value, literal, MPFR_RNDN);
+    }
+    // explicit constructors
+    explicit MpDouble(const char *literal) {
+        mpfr_init(value);
+        mpfr_set_str(value, literal, 10, MPFR_RNDN);
+    }
+    explicit MpDouble(mpfr_t val) {
+        mpfr_swap(value, val);
+    }
+    // destructor
+    ~MpDouble() {
+        mpfr_clear(value);
+    }
+
+    static void setPreccisionInBits(int bits) {
+        mpfr_set_default_prec(bits);
+    }
+
+    static void cleanUp() {
+        mpfr_free_cache();
+    }
+
+    // explicit static cast to double
+    explicit operator double() const {
+        return mpfr_get_d(value, MPFR_RNDN);
+    }
+
+    // assignment operation
+    MpDouble &operator=(const MpDouble &other) {
+        if(this == &other) return *this;
+        mpfr_set(value, other.value, MPFR_RNDN);
+        return *this;
+    }
+    // move assignment operation
+    MpDouble &operator=(MpDouble &&other) {
+        if(this == &other) return *this;
+        mpfr_swap(this->value, other.value);
+        return *this;
+    }
+
+    // arithmetic operations
+    MpDouble &operator+=(const MpDouble &other) {
+        mpfr_t result;
+        mpfr_init(result);
+        mpfr_add(result, value, other.value, MPFR_RNDN);
+        mpfr_swap(value, result);
+        mpfr_clear(result);
+        return *this;
+    }
+    MpDouble &operator-=(const MpDouble &other) {
+        mpfr_t result;
+        mpfr_init(result);
+        mpfr_sub(result, value, other.value, MPFR_RNDN);
+        mpfr_swap(value, result);
+        mpfr_clear(result);
+        return *this;
+    }
+    MpDouble &operator/=(const MpDouble &other) {
+        mpfr_t result;
+        mpfr_init(result);
+        mpfr_div(result, value, other.value, MPFR_RNDN);
+        mpfr_swap(value, result);
+        mpfr_clear(result);
+        return *this;
+    }
+    MpDouble &operator*=(const MpDouble &other) {
+        mpfr_t result;
+        mpfr_init(result);
+        mpfr_mul(result, value, other.value, MPFR_RNDN);
+        mpfr_swap(value, result);
+        mpfr_clear(result);
+        return *this;
+    }
+
+    friend MpDouble operator+(const MpDouble &a, const MpDouble &b);
+    friend MpDouble operator-(const MpDouble &a, const MpDouble &b);
+    friend MpDouble operator/(const MpDouble &a, const MpDouble &b);
+    friend MpDouble operator*(const MpDouble &a, const MpDouble &b);
+
+    friend bool operator>(const MpDouble &a, const MpDouble &b);
+    friend bool operator<(const MpDouble &a, const MpDouble &b);
+    friend bool operator>=(const MpDouble &a, const MpDouble &b);
+    friend bool operator<=(const MpDouble &a, const MpDouble &b);
+    friend bool operator!=(const MpDouble &a, const MpDouble &b);
+    friend bool operator==(const MpDouble &a, const MpDouble &b);
+
+};
+
+MpDouble operator+(const MpDouble &a, const MpDouble &b) {
+    mpfr_t result;
+    mpfr_init(result);
+    mpfr_add(result, a.value, b.value, MPFR_RNDN);
+    return MpDouble {result};
+}
+
+MpDouble operator-(const MpDouble &a, const MpDouble &b) {
+    mpfr_t result;
+    mpfr_init(result);
+    mpfr_sub(result, a.value, b.value, MPFR_RNDN);
+    return MpDouble {result};
+}
+
+MpDouble operator/(const MpDouble &a, const MpDouble &b) {
+
+    mpfr_t result;
+    mpfr_init(result);
+    mpfr_div(result, a.value, b.value, MPFR_RNDN);
+    return MpDouble {result};
+}
+
+MpDouble operator*(const MpDouble &a, const MpDouble &b) {
+    mpfr_t result;
+    mpfr_init(result);
+    mpfr_mul(result, a.value, b.value, MPFR_RNDN);
+    return MpDouble {result};
+}
+
+bool operator>(const MpDouble &a, const MpDouble &b) {
+    return mpfr_greater_p(a.value, b.value);
+}
+
+bool operator<(const MpDouble &a, const MpDouble &b) {
+    return mpfr_less_p(a.value, b.value);
+}
+
+bool operator>=(const MpDouble &a, const MpDouble &b) {
+    return mpfr_greaterequal_p(a.value, b.value);
+}
+
+bool operator<=(const MpDouble &a, const MpDouble &b) {
+    return mpfr_lessequal_p(a.value, b.value);
+}
+
+bool operator==(const MpDouble &a, const MpDouble &b) {
+    return mpfr_equal_p(a.value, b.value);
+}
+
+bool operator!=(const MpDouble &a, const MpDouble &b) {
+    return mpfr_lessgreater_p(a.value, b.value);
+}

--- a/examples/cpp/mp_formula.cpp
+++ b/examples/cpp/mp_formula.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <cmath>
+#include <new>
 
 #include "pf.h"
 #include "mp_double.h"
@@ -58,14 +59,14 @@ static void pf_calc(
     MpDouble t__h_zwpixel_im = t__params[3];
 
     // set some initial values (fate, color ...)
-    MpDouble t__h_index = 0.0;
+    MpDouble t__h_index {0.0};
     int t__h_solid = 0;
     int t__h_fate = 0;
     int t__h_inside = 0;
-    MpDouble t__h_color_re = 0.0;
-    MpDouble t__h_color_i = 0.0;
-    MpDouble t__h_color_j = 0.0;
-    MpDouble t__h_color_k = 0.0;
+    MpDouble t__h_color_re {0.0};
+    MpDouble t__h_color_i {0.0};
+    MpDouble t__h_color_j {0.0};
+    MpDouble t__h_color_k {0.0};
 
     // you could use direct color when using a #color variable in the function
     *t__p_pDirectColorFlag = 0;
@@ -84,17 +85,17 @@ static void pf_calc(
     void *t__a__gradient = t__pfo->p[0].gradient;
     MpDouble t__a_fbailout = t__pfo->p[1].doubleval;
 
-    MpDouble z_re = 0.00000000000000000;
-    MpDouble z_im = 0.00000000000000000;
+    MpDouble z_re {0.0};
+    MpDouble z_im {0.0};
 
     // those temporaries we need to keep them
-    MpDouble t__f5 = 0.00000000000000000;
-    MpDouble t__f6 = 0.00000000000000000;
+    MpDouble t__f5 {0.0};
+    MpDouble t__f6 {0.0};
 
     MpDouble t__a_cf0_offset = t__pfo->p[2].doubleval;
     MpDouble t__a_cf0_density = t__pfo->p[3].doubleval;
     MpDouble t__a_cf0bailout = t__pfo->p[4].doubleval;
-    MpDouble cf0ed = 0.00000000000000000;
+    MpDouble cf0ed {0.0};
 
     MpDouble t__a_cf1_offset = t__pfo->p[5].doubleval;
     MpDouble t__a_cf1_density = t__pfo->p[6].doubleval;
@@ -226,7 +227,7 @@ static void pf_kill(
     struct s_pf_data *p_stub)
 {
     MpDouble::cleanUp();
-    free(p_stub);
+    delete p_stub;
 }
 
 static struct s_pf_vtable vtbl =
@@ -240,7 +241,7 @@ static struct s_pf_vtable vtbl =
 pf_obj *pf_new()
 {
     MpDouble::setPreccisionInBits(432);
-    pf_real *p = (pf_real *)malloc(sizeof(pf_real));
+    pf_real *p = new (std::nothrow) pf_real;
     if (!p)
         return NULL;
     p->parent.vtbl = &vtbl;

--- a/examples/cpp/mp_formula.cpp
+++ b/examples/cpp/mp_formula.cpp
@@ -1,0 +1,248 @@
+#include <cstdlib>
+#include <cmath>
+
+#include "pf.h"
+#include "mp_double.h"
+
+typedef struct
+{
+    pf_obj parent;
+    struct s_param p[PF_MAXPARAMS];
+} pf_real;
+
+static void pf_get_defaults(
+    struct s_pf_data *t__p_stub,
+    double *pos_params,
+    struct s_param *params,
+    int nparams)
+{
+    // do nothing
+}
+
+static void pf_init(
+    struct s_pf_data *p_stub,
+    double *pos_params,
+    struct s_param *params,
+    int nparams)
+{
+    pf_real *pfo = (pf_real *)p_stub;
+    if (nparams > PF_MAXPARAMS)
+    {
+        nparams = PF_MAXPARAMS;
+    }
+    for (int i = 0; i < nparams; ++i)
+    {
+        pfo->p[i] = params[i];
+    }
+}
+
+static void pf_calc(
+    // "object" pointer
+    struct s_pf_data *t__p_stub,
+    // in params
+    const double *t__params, int maxiter, int t__warp_param,
+    // periodicity params
+    int min_period_iter, double period_tolerance,
+    // only used for debugging
+    int t__p_x, int t__p_y, int t__p_aa,
+    // out params
+    int *t__p_pnIters, int *t__p_pFate, double *t__p_pDist, int *t__p_pSolid,
+    int *t__p_pDirectColorFlag, double *t__p_pColors)
+{
+    pf_real *t__pfo = (pf_real *)t__p_stub;
+
+    // get the #pixel (x,y) and #zwpixel (z,w) from position params (x, y, z, w)
+    MpDouble pixel_re = t__params[0];
+    MpDouble pixel_im = t__params[1];
+    MpDouble t__h_zwpixel_re = t__params[2];
+    MpDouble t__h_zwpixel_im = t__params[3];
+
+    // set some initial values (fate, color ...)
+    MpDouble t__h_index = 0.0;
+    int t__h_solid = 0;
+    int t__h_fate = 0;
+    int t__h_inside = 0;
+    MpDouble t__h_color_re = 0.0;
+    MpDouble t__h_color_i = 0.0;
+    MpDouble t__h_color_j = 0.0;
+    MpDouble t__h_color_k = 0.0;
+
+    // you could use direct color when using a #color variable in the function
+    *t__p_pDirectColorFlag = 0;
+
+    // warp param: still not sure how it works but the idea is to change the shape of the image somehow
+    if (t__warp_param != -1)
+    {
+        t__pfo->p[t__warp_param].doubleval = static_cast<double>(t__h_zwpixel_re);
+        t__pfo->p[t__warp_param + 1].doubleval = static_cast<double>(t__h_zwpixel_im);
+        t__h_zwpixel_re = t__h_zwpixel_im = 0.0;
+    }
+
+    // formula params are stored in t__pfo->p array thanks to a previous call of pf_init
+    /* variable declarations */
+    int f__bailout = 0;
+    void *t__a__gradient = t__pfo->p[0].gradient;
+    MpDouble t__a_fbailout = t__pfo->p[1].doubleval;
+
+    MpDouble z_re = 0.00000000000000000;
+    MpDouble z_im = 0.00000000000000000;
+
+    // those temporaries we need to keep them
+    MpDouble t__f5 = 0.00000000000000000;
+    MpDouble t__f6 = 0.00000000000000000;
+
+    MpDouble t__a_cf0_offset = t__pfo->p[2].doubleval;
+    MpDouble t__a_cf0_density = t__pfo->p[3].doubleval;
+    MpDouble t__a_cf0bailout = t__pfo->p[4].doubleval;
+    MpDouble cf0ed = 0.00000000000000000;
+
+    MpDouble t__a_cf1_offset = t__pfo->p[5].doubleval;
+    MpDouble t__a_cf1_density = t__pfo->p[6].doubleval;
+
+    MpDouble old_z_re {0.0};
+    MpDouble old_z_im {0.0};
+    int period_iters = 0;
+    int save_mask = 9;
+    int save_incr = 1;
+    int next_save_incr = 4;
+
+    int t__h_numiter = 0;
+
+t__start_finit:;
+    // init: z = #zwpixel
+    z_re = t__h_zwpixel_re;
+    z_im = t__h_zwpixel_im;
+    goto t__end_finit;
+t__end_finit:;
+
+    old_z_re = z_re;
+    old_z_im = z_im;
+
+    do
+    {
+    t__start_floop:;
+        // loop: (z = sqr(z) + #pixel) same as (z = z*z + #pixel)
+        // complex x complex -> (a+bi)⋅(c+di)=(ac−bd)+(ad+bc)i
+        t__f5 = (z_re * z_re - z_im * z_im) + pixel_re;
+        t__f6 = (2.00000000000000000 * z_re * z_im) + pixel_im;
+        z_re = t__f5;
+        z_im = t__f6;
+        goto t__end_floop;
+    t__end_floop:;
+
+    t__start_fbailout:;
+        // this is the bailout function, in this case "cmag" -> "square modulus"
+        // cmag(a,bi) is equivalent to a*a+b*b
+        f__bailout = (z_re * z_re + z_im * z_im) < t__a_fbailout;
+        goto t__end_fbailout;
+    t__end_fbailout:;
+
+        // check the bailout -> if (cmag(z) > bailout) then finish loop
+        if (!f__bailout)
+            break;
+
+        // period tolerance and min_period_iters:
+        // until we reach the min_period_iter we do nothing
+        // if the difference between the "old value" and the current value is inferior to the period tolerance
+        //   then we finish the loop (the value is not changing too much) considering the value is inside the set (trapped)
+        // we save the "old value" once every n-iterations after the min_period_iters -> this is achieved with the save_mask and save_incr
+        if (t__h_numiter >= min_period_iter)
+        {
+            if ((t__h_numiter & save_mask) == 0)
+            {
+                /* save a value */
+                old_z_re = z_re;
+                old_z_im = z_im;
+
+                if (--save_incr == 0)
+                {
+                    /* lengthen period check */
+                    save_mask = (save_mask << 1) + 1;
+                    save_incr = next_save_incr;
+                }
+            }
+            else
+            {
+                /* compare to an older value */
+                if ((fabs(static_cast<double>(z_re - old_z_re)) < period_tolerance) && (fabs(static_cast<double>(z_im - old_z_im)) < period_tolerance))
+                {
+                    period_iters = t__h_numiter;
+                    //t__h_numiter = maxiter;
+                    t__h_inside = 1;
+                    *t__p_pFate = 1;
+
+                    goto loop_done;
+                }
+            }
+        }
+
+        // increase the number of iterations performed
+        t__h_numiter++;
+    } while (t__h_numiter < maxiter);
+
+    /* fate of 0 = escaped, 1 = trapped */
+    t__h_inside = (t__h_numiter >= maxiter);
+    *t__p_pFate = (t__h_numiter >= maxiter);
+
+loop_done:
+
+    // output the total iterations
+    *t__p_pnIters = t__h_numiter;
+
+    // outside transfer function: "continuous potential"
+    if (t__h_inside == 0)
+    {
+    t__start_cf0final:;
+        // ed = @bailout/(|z| + 1.0e-9)
+        cf0ed = t__a_cf0bailout / ((z_re * z_re + z_im * z_im) + 0.00000000100000000);
+        // #index = (#numiter + ed) / 256.0
+        t__h_index = ((double)t__h_numiter + cf0ed) / 256.00000000000000000;
+        // #index = #index * @density + @offset
+        t__h_index = t__a_cf0_density * t__h_index + t__a_cf0_offset;
+        goto t__end_cf0final;
+    t__end_cf0final:;
+    }
+    else
+    {
+    // outside transfer function: "zero"
+    t__start_cf1final:;
+        // #solid = true
+        t__h_solid = 1;
+        // #index = #index * @density + @offset
+        t__h_index = t__a_cf1_density * t__h_index + t__a_cf1_offset;
+        goto t__end_cf1final;
+    t__end_cf1final:;
+    }
+
+    *t__p_pFate = t__h_fate | (t__h_inside ? FATE_INSIDE : 0);
+    *t__p_pDist = static_cast<double>(t__h_index);
+    *t__p_pSolid = t__h_solid;
+
+
+    return;
+}
+
+static void pf_kill(
+    struct s_pf_data *p_stub)
+{
+    MpDouble::cleanUp();
+    free(p_stub);
+}
+
+static struct s_pf_vtable vtbl =
+{
+    pf_get_defaults,
+    pf_init,
+    pf_calc,
+    pf_kill
+};
+
+pf_obj *pf_new()
+{
+    MpDouble::setPreccisionInBits(432);
+    pf_real *p = (pf_real *)malloc(sizeof(pf_real));
+    if (!p)
+        return NULL;
+    p->parent.vtbl = &vtbl;
+    return (pf_obj *)p;
+}

--- a/examples/cpp/mp_mandelbrot.sh
+++ b/examples/cpp/mp_mandelbrot.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+docker build . -f examples/cpp/Dockerfile -t mp_mandelbrot:1.0.0 \
+    --build-arg main_source=custom_formula.cpp \
+    --build-arg formula_source=examples/cpp/mp_formula.cpp \
+    --build-arg gmp_support=1
+docker run --rm -it -v ${PWD}/examples/output:/src/output mp_mandelbrot:1.0.0


### PR DESCRIPTION
I've added a new example using a wrapper for the [MPFR](https://www.mpfr.org/) library.

The formula now is written in C++, so I had to change a bit the examples infrastructure.

The idea behind this is example is to replace the double type in the formula sources (generated by the fract4d_compiler package) by a new custom type. This new custom type is a wrapper for the MPRF types and functions with operator overload. Having this, the modifications we have to apply to the original formula source are minimal.

Cmake configuration now includes (for all examples) debug information: elapsed time, compiler information and command verbosity. Thus we can compare the different examples.
This is one approach we can investigate for #77 