### PR TITLE
Add pylint singleton-comparison check

### DIFF
--- a/fract4d_compiler/tests/test_symbol.py
+++ b/fract4d_compiler/tests/test_symbol.py
@@ -32,7 +32,7 @@ class SymbolTest(unittest.TestCase):
 
         self.assertEqual(c["foo"].value, 4)
         self.assertEqual(c["@fn1"][0].cname, "sin")
-        self.assertTrue(c[name].is_temp == True)
+        self.assertTrue(c[name].is_temp)
 
     def testParamSlots(self):
         t = fsymbol.T("boo")
@@ -279,7 +279,7 @@ class SymbolTest(unittest.TestCase):
 
     def testTemps(self):
         name = self.t.newTemp(Float)
-        self.assertTrue(self.t[name].is_temp == True)
+        self.assertTrue(self.t[name].is_temp)
 
     def assertIsValidVar(self, val):
         if isinstance(val, Var):

--- a/pylintrc
+++ b/pylintrc
@@ -7,6 +7,7 @@ enable=E,
   unnecessary-semicolon,
   trailing-newlines,
   bare-except,
+  singleton-comparison,
   unused-import
 
 ignore=parsetab.py,lextab.py


### PR DESCRIPTION
singleton-comparison (C0121):
Comparison to %s should be %s Used when an expression is compared to singleton values like True, False or None.
