### PR TITLE
C++ Engine refactor

### DIFF
--- a/docker/bin/run_test.sh
+++ b/docker/bin/run_test.sh
@@ -3,5 +3,5 @@
 docker-compose up -d --build
 docker-compose exec server bash -c "rm -rf build"
 docker-compose exec server bash -c "python3 setup.py build && \
-                                    ./test.py"
+                                    pytest fract4d fract4dgui fract4d_compiler test.py"
 docker-compose down

--- a/examples/cpp/simple_mandelbrot.cpp
+++ b/examples/cpp/simple_mandelbrot.cpp
@@ -14,6 +14,7 @@
 #include "model/calcfunc.h"
 #include "model/enums.h"
 #include "model/imagewriter.h"
+#include "model/calcoptions.h"
 
 #define MAX_ITERATIONS 100
 
@@ -88,25 +89,18 @@ int main() {
     auto im{std::make_unique<image>()};
     im->set_resolution(640, 480, -1, -1);
 
+    calc_options options;
+    options.maxiter = MAX_ITERATIONS;
+
     // LAUNCH CALCULATION
     calc(
+        options,
         const_cast<double *>(pos_params),
-        0, // antialiasing
-        MAX_ITERATIONS,
-        1, // number of threads
         pf_handle,
         cmap.get(),
-        0, // auto deepen
-        0, // auto tolerance
-        1.0E-9, // tolerance
-        0, // y flip
-        1, // periodicity
-        1, // dirty
-        0, // debug flags
-        RENDER_TWO_D, // render type
-        -1, // wrap param
+        site.get(),
         im.get(),
-        site.get()
+        0 // debug flags
     );
 
     // save the image

--- a/fract4d/c/fract4dc/calcargs.cpp
+++ b/fract4d/c/fract4dc/calcargs.cpp
@@ -2,7 +2,6 @@
 
 #include "calcargs.h"
 
-// @TODO: create a subclass for python interfaces and remove these
 #include "fract4dc/colormaps.h"
 #include "fract4dc/sites.h"
 #include "fract4dc/loaders.h"

--- a/fract4d/c/fract4dc/calcargs.cpp
+++ b/fract4d/c/fract4dc/calcargs.cpp
@@ -14,18 +14,6 @@ calc_args::calc_args()
 #ifdef DEBUG_CREATION
     fprintf(stderr, "%p : CA : CTOR\n", this);
 #endif
-    dirty = 1;
-    periodicity = true;
-    yflip = false;
-    auto_deepen = false;
-    auto_tolerance = false;
-    tolerance = 1.0E-9;
-    eaa = AA_NONE;
-    maxiter = 1024;
-    nThreads = 1;
-    render_type = RENDER_TWO_D;
-    asynchronous = false;
-    warp_param = -1;
     params = new double[N_PARAMS];
 }
 

--- a/fract4d/c/fract4dc/calcargs.h
+++ b/fract4d/c/fract4dc/calcargs.h
@@ -29,7 +29,6 @@ struct calc_args
 
     calc_args();
 
-    // @TODO: remove PyObject from this interface for the model classes to be portable
     // possible solution: create a subclass in the python module interface that get's the real object inside this capsules
     void set_cmap(PyObject *pycmap_);
     void set_pfo(PyObject *pypfo_);

--- a/fract4d/c/fract4dc/calcargs.h
+++ b/fract4d/c/fract4dc/calcargs.h
@@ -12,6 +12,7 @@ class IFractalSite;
 
 struct calc_args
 {
+    int asynchronous = false;
     calc_options options;
 
     double *params;

--- a/fract4d/c/fract4dc/calcargs.h
+++ b/fract4d/c/fract4dc/calcargs.h
@@ -1,9 +1,8 @@
 #ifndef __CALCARGS_H_INCLUDED__
 #define __CALCARGS_H_INCLUDED__
 
-#include "model/enums.h"
+#include "model/calcoptions.h"
 
-// @TODO: create a subclass for python interfaces and remove this
 typedef struct _object PyObject;
 // forward references
 typedef struct s_pf_data pf_obj;
@@ -13,14 +12,9 @@ class IFractalSite;
 
 struct calc_args
 {
-    // double params[N_PARAMS]; // @TODO: moved to cpp dynamic initialization to avoid including pf header here
+    calc_options options;
+
     double *params;
-    int eaa, maxiter, nThreads;
-    int auto_deepen, yflip, periodicity, dirty;
-    int auto_tolerance;
-    double tolerance;
-    int asynchronous, warp_param;
-    render_type_t render_type;
     pf_obj *pfo;
     ColorMap *cmap;
     IImage *im;

--- a/fract4d/c/fract4dc/calcs.cpp
+++ b/fract4d/c/fract4dc/calcs.cpp
@@ -43,7 +43,7 @@ namespace calcs {
             return NULL;
         }
 
-        if (cargs->asynchronous)
+        if (cargs->options.asynchronous)
         {
             cargs->site->interrupt();
             cargs->site->wait();
@@ -70,23 +70,15 @@ namespace calcs {
         {
             Py_BEGIN_ALLOW_THREADS
                 // synchronous
-                calc(cargs->params,
-                    cargs->eaa,
-                    cargs->maxiter,
-                    cargs->nThreads,
+                calc(
+                    cargs->options,
+                    cargs->params,
                     cargs->pfo,
                     cargs->cmap,
-                    cargs->auto_deepen,
-                    cargs->auto_tolerance,
-                    cargs->tolerance,
-                    cargs->yflip,
-                    cargs->periodicity,
-                    cargs->dirty,
-                    0, // debug_flags
-                    cargs->render_type,
-                    cargs->warp_param,
+                    cargs->site,
                     cargs->im,
-                    cargs->site);
+                    0 // debug_flags
+                );
 
             delete cargs;
             Py_END_ALLOW_THREADS
@@ -107,16 +99,15 @@ void * calculation_thread(void *vdata)
     fprintf(stderr, "%p : CA : CALC(%d)\n", args, pthread_self());
 #endif
 
-    calc(args->params, args->eaa, args->maxiter,
-         args->nThreads, args->pfo, args->cmap,
-         args->auto_deepen,
-         args->auto_tolerance,
-         args->tolerance,
-         args->yflip, args->periodicity, args->dirty,
-         0, // debug_flags
-         args->render_type,
-         args->warp_param,
-         args->im, args->site);
+    calc(
+        args->options,
+        args->params,
+        args->pfo,
+        args->cmap,
+        args->site,
+        args->im,
+        0 // debug_flags
+    );
 
 #ifdef DEBUG_THREADS
     fprintf(stderr, "%p : CA : ENDCALC(%d)\n", args, pthread_self());
@@ -161,18 +152,18 @@ calc_args * parse_calc_args(PyObject *args, PyObject *kwds)
             &pyim, &pysite,
             &pypfo, &pycmap,
             &pyparams,
-            &cargs->eaa,
-            &cargs->maxiter,
-            &cargs->yflip,
-            &cargs->nThreads,
-            &cargs->auto_deepen,
-            &cargs->periodicity,
-            &cargs->render_type,
-            &cargs->dirty,
-            &cargs->asynchronous,
-            &cargs->warp_param,
-            &cargs->tolerance,
-            &cargs->auto_tolerance))
+            &cargs->options.eaa,
+            &cargs->options.maxiter,
+            &cargs->options.yflip,
+            &cargs->options.nThreads,
+            &cargs->options.auto_deepen,
+            &cargs->options.periodicity,
+            &cargs->options.render_type,
+            &cargs->options.dirty,
+            &cargs->options.asynchronous,
+            &cargs->options.warp_param,
+            &cargs->options.period_tolerance,
+            &cargs->options.auto_tolerance))
     {
         goto error;
     }

--- a/fract4d/c/fract4dc/calcs.cpp
+++ b/fract4d/c/fract4dc/calcs.cpp
@@ -43,7 +43,7 @@ namespace calcs {
             return NULL;
         }
 
-        if (cargs->options.asynchronous)
+        if (cargs->asynchronous)
         {
             cargs->site->interrupt();
             cargs->site->wait();
@@ -160,7 +160,7 @@ calc_args * parse_calc_args(PyObject *args, PyObject *kwds)
             &cargs->options.periodicity,
             &cargs->options.render_type,
             &cargs->options.dirty,
-            &cargs->options.asynchronous,
+            &cargs->asynchronous,
             &cargs->options.warp_param,
             &cargs->options.period_tolerance,
             &cargs->options.auto_tolerance))

--- a/fract4d/c/fract4dc/controllers.cpp
+++ b/fract4d/c/fract4dc/controllers.cpp
@@ -70,23 +70,13 @@ void fractal_controller::start_calculating(PyObject *pyimage, PyObject *pycmap, 
     auto calc_fn = [](void *data) mutable -> void* {
         fractal_controller *fc = (fractal_controller *)data;
         calc(
+            fc->c_options,
             fc->c_pos_params,
-            fc->c_options.eaa,
-            fc->c_options.maxiter,
-            fc->c_options.nThreads,
             fc->pf_handle,
             fc->cmap,
-            fc->c_options.auto_deepen,
-            fc->c_options.auto_tolerance,
-            fc->c_options.tolerance,
-            fc->c_options.yflip,
-            fc->c_options.periodicity,
-            fc->c_options.dirty,
-            0,
-            fc->c_options.render_type,
-            fc->c_options.warp_param,
+            fc->site,
             fc->image,
-            fc->site
+            0
         );
         return nullptr;
     };

--- a/fract4d/c/fract4dc/controllers.cpp
+++ b/fract4d/c/fract4dc/controllers.cpp
@@ -48,7 +48,10 @@ void fractal_controller::set_fd(int fd) {
     site = new FDSite(fd);
 }
 
-void fractal_controller::start_calculating(PyObject *pyimage, PyObject *pycmap, PyObject *pyparams, calc_options coptions) {
+void fractal_controller::start_calculating(
+    PyObject *pyimage, PyObject *pycmap, PyObject *pyparams,
+    calc_options coptions, bool asynchronous
+    ) {
     c_pos_params = new double[N_PARAMS];
     if (!parse_posparams(pyparams, c_pos_params))
     {
@@ -81,7 +84,7 @@ void fractal_controller::start_calculating(PyObject *pyimage, PyObject *pycmap, 
         return nullptr;
     };
 
-    if (coptions.asynchronous) {
+    if (asynchronous) {
         site->interrupt();
         site->wait();
         site->start();

--- a/fract4d/c/fract4dc/controllers.h
+++ b/fract4d/c/fract4dc/controllers.h
@@ -3,30 +3,12 @@
 
 #include "Python.h"
 
-#include "model/enums.h"
+#include "model/calcoptions.h"
 
 typedef struct s_pf_data pf_obj;
 class IFractalSite;
 class ColorMap;
 class IImage;
-
-// @todo: review C++ standar version support
-struct calc_options
-{
-    int
-        eaa = AA_NONE,
-        maxiter =  1024,
-        nThreads = 1,
-        auto_deepen = false,
-        yflip = false,
-        periodicity = true,
-        dirty = 1,
-        auto_tolerance = false,
-        asynchronous = false,
-        warp_param = -1;
-    double tolerance = 1.0E-9;
-    render_type_t render_type = RENDER_TWO_D;
-};
 
 typedef struct fractal_controller {
     PyObject_HEAD

--- a/fract4d/c/fract4dc/controllers.h
+++ b/fract4d/c/fract4dc/controllers.h
@@ -23,7 +23,7 @@ typedef struct fractal_controller {
     PyObject *py_image;
     void set_message_handler(PyObject *message_handler);
     void set_fd(int fd);
-    void start_calculating(PyObject *pyimage, PyObject *pycmap, PyObject *pyparams, calc_options coptions);
+    void start_calculating(PyObject *pyimage, PyObject *pycmap, PyObject *pyparams, calc_options coptions, bool asynchronous);
     void stop_calculating();
     void free_resources();
     ~fractal_controller();

--- a/fract4d/c/fract4dc/functions.cpp
+++ b/fract4d/c/fract4dc/functions.cpp
@@ -78,7 +78,7 @@ namespace functions {
 
         PyObject *pyret = PyCapsule_New(ffh, OBTYPE_FFH, pyff_delete);
 
-        // @TODO: why?
+        // refcount worker so it can't be unloaded before funct is gone
         Py_INCREF(pyworker);
 
         return pyret;

--- a/fract4d/c/fract4dc/functions.cpp
+++ b/fract4d/c/fract4dc/functions.cpp
@@ -10,6 +10,7 @@
 #include "model/enums.h"
 #include "model/worker.h"
 #include "model/fractfunc.h"
+#include "model/calcoptions.h"
 
 #include "pf.h"
 
@@ -19,17 +20,12 @@ namespace functions {
     {
         PyObject *pypfo, *pycmap, *pyim, *pysite, *pyworker;
         double params[N_PARAMS];
-        int eaa = -7, maxiter = -8, nThreads = -9;
-        int auto_deepen, periodicity;
-        int yflip;
-        render_type_t render_type;
         pf_obj *pfo;
         ColorMap *cmap;
         IImage *im;
         IFractalSite *site;
         IFractWorker *worker;
-        int auto_tolerance;
-        double tolerance;
+        calc_options options;
 
         if (!PyArg_ParseTuple(
                 args,
@@ -37,14 +33,14 @@ namespace functions {
                 &params[0], &params[1], &params[2], &params[3],
                 &params[4], &params[5], &params[6], &params[7],
                 &params[8], &params[9], &params[10],
-                &eaa, &maxiter, &yflip, &nThreads,
+                &options.eaa, &options.maxiter, &options.yflip, &options.nThreads,
                 &pypfo, &pycmap,
-                &auto_deepen,
-                &periodicity,
-                &render_type,
+                &options.auto_deepen,
+                &options.periodicity,
+                &options.render_type,
                 &pyim, &pysite,
                 &pyworker,
-                &auto_tolerance, &tolerance))
+                &options.auto_tolerance, &options.period_tolerance))
         {
             return NULL;
         }
@@ -61,17 +57,8 @@ namespace functions {
         }
 
         fractFunc *ff = new fractFunc(
+            options,
             params,
-            eaa,
-            maxiter,
-            nThreads,
-            auto_deepen,
-            auto_tolerance,
-            tolerance,
-            yflip,
-            periodicity,
-            render_type,
-            -1, // warp_param
             worker,
             im,
             site);

--- a/fract4d/c/fract4dc/pysite.h
+++ b/fract4d/c/fract4dc/pysite.h
@@ -5,7 +5,6 @@
 
 typedef struct _object PyObject;
 
-// @TODO: this sub-class should be moved out of this model into the Python interface to keep this module portable
 class PySite : public IFractalSite
 {
 public:

--- a/fract4d/c/fract4dc/workers.cpp
+++ b/fract4d/c/fract4dc/workers.cpp
@@ -50,7 +50,7 @@ namespace workers {
 
         IFractWorker *worker = IFractWorker::create(nThreads, pfo, cmap, im, site);
 
-        if (!worker->ok())
+        if (!worker)
         {
             PyErr_SetString(PyExc_ValueError, "Error creating worker");
             delete worker;

--- a/fract4d/c/fract4dmodule.cpp
+++ b/fract4d/c/fract4dmodule.cpp
@@ -476,6 +476,7 @@ Controller_start_calculating(FractalController *self, PyObject *args, PyObject *
     PyObject *cmap;
     PyObject *params;
     calc_options coptions {};
+    int asynchronous = false;
     if (PyArg_ParseTupleAndKeywords(args, kwds, "OOO|iiiiiiiiiidi", const_cast<char **>(kwlist),
         &image,
         &cmap,
@@ -488,13 +489,13 @@ Controller_start_calculating(FractalController *self, PyObject *args, PyObject *
         &coptions.periodicity,
         &coptions.render_type,
         &coptions.dirty,
-        &coptions.asynchronous,
+        &asynchronous,
         &coptions.warp_param,
         &coptions.period_tolerance,
         &coptions.auto_tolerance
         ))
     {
-        self->start_calculating(image, cmap, params, coptions);
+        self->start_calculating(image, cmap, params, coptions, asynchronous);
     }
     Py_INCREF(Py_None);
     return Py_None;

--- a/fract4d/c/fract4dmodule.cpp
+++ b/fract4d/c/fract4dmodule.cpp
@@ -687,7 +687,7 @@ static struct PyModuleDef moduledef = {
     NULL, // extension_clear
     NULL};
 
-extern "C" PyMODINIT_FUNC
+PyMODINIT_FUNC
 PyInit_fract4dc(void)
 {
     // had to do this here because some compilers don't support non-trivial designated initializers

--- a/fract4d/c/fract4dmodule.cpp
+++ b/fract4d/c/fract4dmodule.cpp
@@ -30,6 +30,7 @@
 #include "fract4dc/controllers.h"
 
 #include "model/enums.h"
+#include "model/calcoptions.h"
 
 struct module_state
 {
@@ -489,7 +490,7 @@ Controller_start_calculating(FractalController *self, PyObject *args, PyObject *
         &coptions.dirty,
         &coptions.asynchronous,
         &coptions.warp_param,
-        &coptions.tolerance,
+        &coptions.period_tolerance,
         &coptions.auto_tolerance
         ))
     {

--- a/fract4d/c/model/MTFractWorker.cpp
+++ b/fract4d/c/model/MTFractWorker.cpp
@@ -7,94 +7,95 @@
 #include "pf.h"
 
 MTFractWorker::MTFractWorker(
-    int n,
+    int numThreads,
     pf_obj *pfo,
     ColorMap *cmap,
     IImage *im,
     IFractalSite *site)
-    : nWorkers{n > 1 ? n + 1 : 1}, ptf()
+    : m_workers()
 {
     /* 0'th ftf is in this thread for calculations we don't want to offload */
-    ptf.reserve(nWorkers);
-    for (int i = 0; i < nWorkers; ++i)
+    const auto numWorkers = numThreads > 1 ? numThreads + 1 : 1;
+
+    m_workers.reserve(numWorkers);
+    for (int i = 0; i < numWorkers; ++i)
     {
-        STFractWorker &stfw = ptf.emplace_back(pfo, cmap, im, site);
+        STFractWorker &stfw = m_workers.emplace_back(pfo, cmap, im, site);
         if (!stfw.ok())
         {
             m_ok = false;
         }
     }
-    if (n > 1)
+    if (numThreads > 1)
     {
-        ptp = std::make_unique<tpool<job_info_t, STFractWorker>>(n, 1000, &ptf[0]);
+        m_threads = std::make_unique<tpool<job_info_t, STFractWorker>>(numThreads, 1000, &m_workers[0]);
     }
 }
 
 void MTFractWorker::set_fractFunc(fractFunc *ff_)
 {
-    for (int i = 0; i < nWorkers; ++i)
+    for (auto& worker: m_workers)
     {
-        ptf[i].set_fractFunc(ff_);
+        worker.set_fractFunc(ff_);
     }
 }
 
 void MTFractWorker::row_aa(int x, int y, int n)
 {
-    if (nWorkers > 1 && n > 8)
+    if (m_threads && n > 8)
     {
         send_row_aa(x, y, n);
     }
     else
     {
-        ptf[0].row_aa(x, y, n);
+        m_workers[0].row_aa(x, y, n);
     }
 }
 
 void MTFractWorker::row(int x, int y, int n)
 {
-    if (nWorkers > 1 && n > 8)
+    if (m_threads && n > 8)
     {
         send_row(x, y, n);
     }
     else
     {
-        ptf[0].row(x, y, n);
+        m_workers[0].row(x, y, n);
     }
 }
 
 void MTFractWorker::box(int x, int y, int rsize)
 {
-    ptf[0].box(x, y, rsize);
+    m_workers[0].box(x, y, rsize);
 }
 
 void MTFractWorker::box_row(int w, int y, int rsize)
 {
-    if (nWorkers > 1)
+    if (m_threads)
     {
         send_box_row(w, y, rsize);
     }
     else
     {
-        ptf[0].box_row(w, y, rsize);
+        m_workers[0].box_row(w, y, rsize);
     }
 }
 
 void MTFractWorker::qbox_row(int w, int y, int rsize, int drawsize)
 {
-    if (nWorkers > 1)
+    if (m_threads)
     {
         send_qbox_row(w, y, rsize, drawsize);
     }
     else
     {
-        ptf[0].qbox_row(w, y, rsize, drawsize);
+        m_workers[0].qbox_row(w, y, rsize, drawsize);
     }
 }
 
 void MTFractWorker::pixel(int x, int y, int w, int h)
 {
-    //assert(0 && "unexpected");
-    ptf[0].pixel(x, y, w, h);
+    m_workers[0].pixel(x, y, w, h);
 }
 
 void MTFractWorker::pixel_aa(int x, int y)
@@ -103,23 +104,22 @@ void MTFractWorker::pixel_aa(int x, int y)
 
 void MTFractWorker::reset_counts()
 {
-    for (int i = 0; i < nWorkers; ++i)
-    {
-        ptf[i].reset_counts();
+    for (auto& worker: m_workers) {
+        worker.reset_counts();
     }
 }
 
 const pixel_stat_t &MTFractWorker::get_stats() const
 {
     // recompute the sums on the fly
-    stats.reset();
+    m_stats.reset();
 
-    for (int i = 0; i < nWorkers; ++i)
+    for (auto& worker: m_workers)
     {
-        const pixel_stat_t &stat = ptf[i].get_stats();
-        stats.add(stat);
+        const pixel_stat_t &stat = worker.get_stats();
+        m_stats.add(stat);
     }
-    return stats;
+    return m_stats;
 }
 
 void MTFractWorker::send_cmd(job_type_t job, int x, int y, int param, int param2)
@@ -130,7 +130,7 @@ void MTFractWorker::send_cmd(job_type_t job, int x, int y, int param, int param2
     work.y = y;
     work.param = param;
     work.param2 = param2;
-    ptp->add_work(worker, work);
+    m_threads->add_work(worker, work);
 }
 
 void MTFractWorker::send_row(int x, int y, int w)
@@ -165,13 +165,13 @@ void MTFractWorker::send_row_aa(int x, int y, int w)
 
 void MTFractWorker::flush()
 {
-    if (ptp)
+    if (m_threads)
     {
-        ptp->flush();
+        m_threads->flush();
     }
 }
 
 bool MTFractWorker::find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root)
 {
-    return ptf[0].find_root(eye, look, root);
+    return m_workers[0].find_root(eye, look, root);
 }

--- a/fract4d/c/model/MTFractWorker.cpp
+++ b/fract4d/c/model/MTFractWorker.cpp
@@ -21,10 +21,6 @@ MTFractWorker::MTFractWorker(
     for (int i = 0; i < numWorkers; ++i)
     {
         STFractWorker &stfw = m_workers.emplace_back(pfo, cmap, im, site);
-        if (!stfw.ok())
-        {
-            m_ok = false;
-        }
     }
     if (numThreads > 1)
     {

--- a/fract4d/c/model/MTFractWorker.cpp
+++ b/fract4d/c/model/MTFractWorker.cpp
@@ -122,17 +122,6 @@ const pixel_stat_t &MTFractWorker::get_stats() const
     return stats;
 }
 
-void MTFractWorker::send_cmd(job_type_t job, int x, int y, int param)
-{
-    job_info_t work;
-    work.job = job;
-    work.x = x;
-    work.y = y;
-    work.param = param;
-    work.param2 = 0;
-    ptp->add_work(worker, work);
-}
-
 void MTFractWorker::send_cmd(job_type_t job, int x, int y, int param, int param2)
 {
     job_info_t work;

--- a/fract4d/c/model/MTFractWorker.cpp
+++ b/fract4d/c/model/MTFractWorker.cpp
@@ -3,7 +3,6 @@
 #include "model/colormap.h"
 #include "model/image.h"
 #include "model/site.h"
-#include "model/threadpool.h"
 
 #include "pf.h"
 
@@ -13,7 +12,7 @@ MTFractWorker::MTFractWorker(
     ColorMap *cmap,
     IImage *im,
     IFractalSite *site)
-    : nWorkers{n > 1 ? n + 1 : 1}, ptf(), m_ok{true}
+    : nWorkers{n > 1 ? n + 1 : 1}, ptf()
 {
     /* 0'th ftf is in this thread for calculations we don't want to offload */
     ptf.reserve(nWorkers);
@@ -29,10 +28,6 @@ MTFractWorker::MTFractWorker(
     {
         ptp = std::make_unique<tpool<job_info_t, STFractWorker>>(n, 1000, &ptf[0]);
     }
-}
-
-MTFractWorker::~MTFractWorker()
-{
 }
 
 void MTFractWorker::set_fractFunc(fractFunc *ff_)
@@ -185,11 +180,6 @@ void MTFractWorker::flush()
     {
         ptp->flush();
     }
-}
-
-bool MTFractWorker::ok()
-{
-    return m_ok;
 }
 
 bool MTFractWorker::find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root)

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <utility>
+#include <cassert>
 
 #include "model/worker.h"
 
@@ -11,33 +12,34 @@
 
 #include "pf.h"
 
-STFractWorker::STFractWorker(pf_obj *pfo, ColorMap *cmap, IImage *im_, IFractalSite *site_) noexcept:
-    options{nullptr}, site{site_}, ff{nullptr}, im{im_}, lastIter{0}
+STFractWorker::STFractWorker(pf_obj *pfo, ColorMap *cmap, IImage *im, IFractalSite *site) noexcept:
+    m_site{site}, m_im{im}, m_lastPointIters{0}
 {
-    pf = std::unique_ptr<pointFunc>(pointFunc::create(pfo, cmap));
-    if (!pf)
+    m_pf = std::unique_ptr<pointFunc>(pointFunc::create(pfo, cmap));
+    if (!m_pf)
     {
         m_ok = false;
     }
 }
 
 STFractWorker::STFractWorker(STFractWorker &&original) noexcept:
-    options{original.options}, ff{original.ff}, im{original.im}, pf{std::move(original.pf)}, lastIter{original.lastIter}
+    m_options{original.m_options}, m_ff{original.m_ff},
+    m_im{original.m_im}, m_pf{std::move(original.m_pf)}, m_lastPointIters{original.m_lastPointIters}
 {
-    this->m_ok = original.m_ok;
-    this->stats = original.stats;
+    m_ok = original.m_ok;
+    m_stats = original.m_stats;
 }
 
 void STFractWorker::set_fractFunc(fractFunc *ff_)
 {
-    ff = ff_;
-    this->options = &ff_->options;
+    m_ff = ff_;
+    m_options = &ff_->options;
 }
 
 /* we're in a worker thread */
 void STFractWorker::work(job_info_t &tdata)
 {
-    if (ff->try_finished_cond())
+    if (m_ff->try_finished_cond())
     {
         // interrupted - just return without doing anything
         // this is less efficient than clearing the queue but easier
@@ -75,9 +77,9 @@ void STFractWorker::work(job_info_t &tdata)
     default:
         printf("Unknown job id %d ignored\n", static_cast<int>(tdata.job));
     }
-    ff->image_changed(0, tdata.y, im->Xres(), tdata.y + nRows);
-    const float new_progress = static_cast<float>(tdata.y) / static_cast<float>(im->Yres());
-    ff->progress_changed(new_progress);
+    m_ff->image_changed(0, tdata.y, m_im->Xres(), tdata.y + nRows);
+    const float new_progress = static_cast<float>(tdata.y) / static_cast<float>(m_im->Yres());
+    m_ff->progress_changed(new_progress);
 }
 
 void STFractWorker::row_aa(int x, int y, int w)
@@ -90,17 +92,17 @@ void STFractWorker::row_aa(int x, int y, int w)
 
 inline int STFractWorker::periodGuess()
 {
-    if (!options->periodicity)
+    if (!m_options->periodicity)
     {
-        return options->maxiter;
+        return m_options->maxiter;
     }
-    if (lastIter == -1)
+    if (m_lastPointIters == -1)
     {
         // we were captured last time so probably will be again
         return 0;
     }
     // we escaped, so don't try so hard this time
-    return lastIter + 10;
+    return m_lastPointIters + 10;
 }
 
 inline int STFractWorker::periodGuess(int x, int y)
@@ -109,20 +111,20 @@ inline int STFractWorker::periodGuess(int x, int y)
     {
         return periodGuess();
     }
-    fate_t previousxFate = im->getFate(x - 1, y, 0);
+    fate_t previousxFate = m_im->getFate(x - 1, y, 0);
     if (FATE_UNKNOWN == previousxFate)
     {
         return periodGuess();
     }
-    int last = im->getIter(x - 1, y);
+    int last = m_im->getIter(x - 1, y);
     return periodGuess(last);
 }
 
 inline int STFractWorker::periodGuess(int last)
 {
-    if (!options->periodicity)
+    if (!m_options->periodicity)
     {
-        return options->maxiter;
+        return m_options->maxiter;
     }
     if (last == -1)
     {
@@ -130,12 +132,12 @@ inline int STFractWorker::periodGuess(int last)
         return 0;
     }
     // we escaped, so don't try so hard this time
-    return lastIter + 10;
+    return m_lastPointIters + 10;
 }
 
 inline void STFractWorker::periodSet(int *ppos)
 {
-    lastIter = *ppos;
+    m_lastPointIters = *ppos;
 }
 
 void STFractWorker::row(int x, int y, int n)
@@ -156,24 +158,24 @@ void STFractWorker::col(int x, int y, int n)
 
 void STFractWorker::reset_counts()
 {
-    stats.reset();
+    m_stats.reset();
 }
 
 const pixel_stat_t &STFractWorker::get_stats() const
 {
-    return stats;
+    return m_stats;
 }
 
 inline int STFractWorker::Pixel2INT(int x, int y)
 {
-    return static_cast<int>(im->get(x, y));
+    return static_cast<int>(m_im->get(x, y));
 }
 
 inline bool STFractWorker::isTheSame(int targetIter, int targetCol, int x, int y)
 {
     // does this point have the target # of iterations?
     // does it have the same colour too?
-    if ((im->getIter(x, y) == targetIter) && (Pixel2INT(x, y) == targetCol)) {
+    if ((m_im->getIter(x, y) == targetIter) && (Pixel2INT(x, y) == targetCol)) {
         return true;
     }
     return false;
@@ -181,99 +183,99 @@ inline bool STFractWorker::isTheSame(int targetIter, int targetCol, int x, int y
 
 rgba_t STFractWorker::antialias(int x, int y)
 {
-    dvec4 topleft = ff->aa_topleft + x * ff->deltax + y * ff->deltay;
+    dvec4 topleft = m_ff->aa_topleft + x * m_ff->deltax + y * m_ff->deltay;
     dvec4 pos = topleft;
     rgba_t ptmp, last;
     unsigned int pixel_r_val = 0, pixel_g_val = 0, pixel_b_val = 0;
     int p = 0;
     float index;
     fate_t fate;
-    int single_iters = im->getIter(x, y);
+    int single_iters = m_im->getIter(x, y);
     int checkPeriod = periodGuess(single_iters);
-    if (ff->debug_flags & DEBUG_DRAWING_STATS)
+    if (m_ff->debug_flags & DEBUG_DRAWING_STATS)
     {
         printf("doaa %d %d\n", x, y);
     }
-    last = im->get(x, y);
+    last = m_im->get(x, y);
     // top left
-    fate = im->getFate(x, y, 0);
-    if (im->hasUnknownSubpixels(x, y))
+    fate = m_im->getFate(x, y, 0);
+    if (m_im->hasUnknownSubpixels(x, y))
     {
-        pf->calc(
-            pos.n, options->maxiter,
-            checkPeriod, options->period_tolerance,
-            options->warp_param,
+        m_pf->calc(
+            pos.n, m_options->maxiter,
+            checkPeriod, m_options->period_tolerance,
+            m_options->warp_param,
             x, y, 1,
             &ptmp, &p, &index, &fate);
-        im->setFate(x, y, 0, fate);
-        im->setIndex(x, y, 0, index);
+        m_im->setFate(x, y, 0, fate);
+        m_im->setIndex(x, y, 0, index);
     }
     else
     {
-        ptmp = pf->recolor(im->getIndex(x, y, 0), fate, last);
+        ptmp = m_pf->recolor(m_im->getIndex(x, y, 0), fate, last);
     }
     pixel_r_val += ptmp.r;
     pixel_g_val += ptmp.g;
     pixel_b_val += ptmp.b;
     // top right
-    fate = im->getFate(x, y, 1);
+    fate = m_im->getFate(x, y, 1);
     if (fate == FATE_UNKNOWN)
     {
-        pos += ff->delta_aa_x;
-        pf->calc(
-            pos.n, options->maxiter,
-            checkPeriod, options->period_tolerance,
-            options->warp_param,
+        pos += m_ff->delta_aa_x;
+        m_pf->calc(
+            pos.n, m_options->maxiter,
+            checkPeriod, m_options->period_tolerance,
+            m_options->warp_param,
             x, y, 2,
             &ptmp, &p, &index, &fate);
-        im->setFate(x, y, 1, fate);
-        im->setIndex(x, y, 1, index);
+        m_im->setFate(x, y, 1, fate);
+        m_im->setIndex(x, y, 1, index);
     }
     else
     {
-        ptmp = pf->recolor(im->getIndex(x, y, 1), fate, last);
+        ptmp = m_pf->recolor(m_im->getIndex(x, y, 1), fate, last);
     }
     pixel_r_val += ptmp.r;
     pixel_g_val += ptmp.g;
     pixel_b_val += ptmp.b;
     // bottom left
-    fate = im->getFate(x, y, 2);
+    fate = m_im->getFate(x, y, 2);
     if (fate == FATE_UNKNOWN)
     {
-        pos = topleft + ff->delta_aa_y;
-        pf->calc(
-            pos.n, options->maxiter,
-            checkPeriod, options->period_tolerance,
-            options->warp_param,
+        pos = topleft + m_ff->delta_aa_y;
+        m_pf->calc(
+            pos.n, m_options->maxiter,
+            checkPeriod, m_options->period_tolerance,
+            m_options->warp_param,
             x, y, 3,
             &ptmp, &p, &index, &fate);
-        im->setFate(x, y, 2, fate);
-        im->setIndex(x, y, 2, index);
+        m_im->setFate(x, y, 2, fate);
+        m_im->setIndex(x, y, 2, index);
     }
     else
     {
-        ptmp = pf->recolor(im->getIndex(x, y, 2), fate, last);
+        ptmp = m_pf->recolor(m_im->getIndex(x, y, 2), fate, last);
     }
     pixel_r_val += ptmp.r;
     pixel_g_val += ptmp.g;
     pixel_b_val += ptmp.b;
     // bottom right
-    fate = im->getFate(x, y, 3);
+    fate = m_im->getFate(x, y, 3);
     if (fate == FATE_UNKNOWN)
     {
-        pos = topleft + ff->delta_aa_y + ff->delta_aa_x;
-        pf->calc(
-            pos.n, options->maxiter,
-            checkPeriod, options->period_tolerance,
-            options->warp_param,
+        pos = topleft + m_ff->delta_aa_y + m_ff->delta_aa_x;
+        m_pf->calc(
+            pos.n, m_options->maxiter,
+            checkPeriod, m_options->period_tolerance,
+            m_options->warp_param,
             x, y, 4,
             &ptmp, &p, &index, &fate);
-        im->setFate(x, y, 3, fate);
-        im->setIndex(x, y, 3, index);
+        m_im->setFate(x, y, 3, fate);
+        m_im->setIndex(x, y, 3, index);
     }
     else
     {
-        ptmp = pf->recolor(im->getIndex(x, y, 3), fate, last);
+        ptmp = m_pf->recolor(m_im->getIndex(x, y, 3), fate, last);
     }
     pixel_r_val += ptmp.r;
     pixel_g_val += ptmp.g;
@@ -286,27 +288,27 @@ rgba_t STFractWorker::antialias(int x, int y)
 
 void STFractWorker::compute_stats(const dvec4 &pos, int iter, fate_t fate, int x, int y)
 {
-    stats.s[ITERATIONS] += iter;
-    stats.s[PIXELS]++;
-    stats.s[PIXELS_CALCULATED]++;
+    m_stats.s[ITERATIONS] += iter;
+    m_stats.s[PIXELS]++;
+    m_stats.s[PIXELS_CALCULATED]++;
     if (fate & FATE_INSIDE)
     {
-        stats.s[PIXELS_INSIDE]++;
-        if (iter < options->maxiter - 1)
+        m_stats.s[PIXELS_INSIDE]++;
+        if (iter < m_options->maxiter - 1)
         {
-            stats.s[PIXELS_PERIODIC]++;
+            m_stats.s[PIXELS_PERIODIC]++;
         }
     }
     else
     {
-        stats.s[PIXELS_OUTSIDE]++;
+        m_stats.s[PIXELS_OUTSIDE]++;
     }
-    if (options->auto_deepen && stats.s[PIXELS] % ff->AUTO_DEEPEN_FREQUENCY == 0)
+    if (m_options->auto_deepen && m_stats.s[PIXELS] % m_ff->AUTO_DEEPEN_FREQUENCY == 0)
     {
         compute_auto_deepen_stats(pos, iter, x, y);
     }
-    if (options->periodicity && options->auto_tolerance &&
-        stats.s[PIXELS] % ff->AUTO_TOLERANCE_FREQUENCY == 0)
+    if (m_options->periodicity && m_options->auto_tolerance &&
+        m_stats.s[PIXELS] % m_ff->AUTO_TOLERANCE_FREQUENCY == 0)
     {
         compute_auto_tolerance_stats(pos, iter, x, y);
     }
@@ -324,10 +326,10 @@ void STFractWorker::compute_auto_tolerance_stats(const dvec4 &pos, int iter, int
         fate_t temp_fate;
         int temp_iter;
         /* try again with 10x tighter tolerance */
-        pf->calc(
-            pos.n, options->maxiter,
-            0, options->period_tolerance / 10.0,
-            options->warp_param,
+        m_pf->calc(
+            pos.n, m_options->maxiter,
+            0, m_options->period_tolerance / 10.0,
+            m_options->warp_param,
             x, y, -1,
             &temp_pixel, &temp_iter, &temp_index, &temp_fate);
 
@@ -335,7 +337,7 @@ void STFractWorker::compute_auto_tolerance_stats(const dvec4 &pos, int iter, int
         {
             // current tolerance is too loose, we would get 1 more
             // pixel correct if we tightened it
-            stats.s[BETTER_TOLERANCE_PIXELS]++;
+            m_stats.s[BETTER_TOLERANCE_PIXELS]++;
         }
     }
     else
@@ -348,28 +350,28 @@ void STFractWorker::compute_auto_tolerance_stats(const dvec4 &pos, int iter, int
         fate_t temp_fate;
         int temp_iter;
         /* try again with 10x looser tolerance */
-        pf->calc(
-            pos.n, options->maxiter,
-            0, options->period_tolerance * 10.0,
-            options->warp_param,
+        m_pf->calc(
+            pos.n, m_options->maxiter,
+            0, m_options->period_tolerance * 10.0,
+            m_options->warp_param,
             x, y, -1,
             &temp_pixel, &temp_iter, &temp_index, &temp_fate);
 
         if (temp_iter == -1)
         {
             // if we loosened, we'd get this pixel wrong
-            stats.s[WORSE_TOLERANCE_PIXELS]++;
+            m_stats.s[WORSE_TOLERANCE_PIXELS]++;
         }
     }
 }
 
 void STFractWorker::compute_auto_deepen_stats(const dvec4 &pos, int iter, int x, int y)
 {
-    if (iter > options->maxiter / 2)
+    if (iter > m_options->maxiter / 2)
     {
         /* we would have got this wrong if we used
 	    * half as many iterations */
-        stats.s[WORSE_DEPTH_PIXELS]++;
+        m_stats.s[WORSE_DEPTH_PIXELS]++;
     }
     else if (iter == -1)
     {
@@ -378,10 +380,10 @@ void STFractWorker::compute_auto_deepen_stats(const dvec4 &pos, int iter, int x,
         fate_t temp_fate;
         int temp_iter;
         /* didn't bail out, try again with 2x as many iterations */
-        pf->calc(
-            pos.n, options->maxiter * 2,
-            periodGuess(), options->period_tolerance,
-            options->warp_param,
+        m_pf->calc(
+            pos.n, m_options->maxiter * 2,
+            periodGuess(), m_options->period_tolerance,
+            m_options->warp_param,
             x, y, -1,
             &temp_pixel, &temp_iter, &temp_index, &temp_fate);
 
@@ -389,40 +391,40 @@ void STFractWorker::compute_auto_deepen_stats(const dvec4 &pos, int iter, int x,
         {
             /* we would have got this right if we used
 	        twice as many iterations */
-            stats.s[BETTER_DEPTH_PIXELS]++;
+            m_stats.s[BETTER_DEPTH_PIXELS]++;
         }
     }
 }
 
 void STFractWorker::pixel(int x, int y, int w, int h)
 {
-    assert(pf != NULL && m_ok == true);
+    assert(m_pf != NULL && m_ok == true);
     rgba_t pixel;
     float index {0};
-    fate_t fate = im->getFate(x, y, 0);
+    fate_t fate = m_im->getFate(x, y, 0);
     if (fate == FATE_UNKNOWN)
     {
         int iter = 0;
-        switch (options->render_type)
+        switch (m_options->render_type)
         {
         case RENDER_TWO_D:
         {
             // calculate coords of this point
-            dvec4 pos = ff->topleft + x * ff->deltax + y * ff->deltay;
+            dvec4 pos = m_ff->topleft + x * m_ff->deltax + y * m_ff->deltay;
             //printf("(%d,%d -> %g,%g,%g,%g) [%x]\n",
             //	   x,y,pos[VX],pos[VY],pos[VZ],pos[VW], (unsigned int)pthread_self());
             const int min_period_iters = periodGuess();
-            pf->calc(
-                pos.n, options->maxiter,
-                min_period_iters, options->period_tolerance,
-                options->warp_param,
+            m_pf->calc(
+                pos.n, m_options->maxiter,
+                min_period_iters, m_options->period_tolerance,
+                m_options->warp_param,
                 x, y, 0,
                 &pixel, &iter, &index, &fate);
             compute_stats(pos, iter, fate, x, y);
 
             const int color_iters = (fate & FATE_INSIDE) ? -1 : iter;
-            site->pixel_changed(
-                pos.n, options->maxiter, min_period_iters,
+            m_site->pixel_changed(
+                pos.n, m_options->maxiter, min_period_iters,
                 x, y, 0,
                 index, fate, color_iters,
                 pixel.r, pixel.g, pixel.b, pixel.a);
@@ -433,9 +435,9 @@ void STFractWorker::pixel(int x, int y, int w, int h)
             break;
         case RENDER_THREE_D:
         {
-            dvec4 look = ff->vec_for_point(x, y);
+            dvec4 look = m_ff->vec_for_point(x, y);
             dvec4 root;
-            bool found = find_root(ff->eye_point, look, root);
+            bool found = find_root(m_ff->eye_point, look, root);
             if (found)
             {
                 // intersected
@@ -456,19 +458,19 @@ void STFractWorker::pixel(int x, int y, int w, int h)
         break;
         }
         periodSet(&iter);
-        if (ff->debug_flags & DEBUG_DRAWING_STATS)
+        if (m_ff->debug_flags & DEBUG_DRAWING_STATS)
         {
             printf("pixel %d %d %d %d\n", x, y, fate, iter);
         }
         assert(fate != FATE_UNKNOWN);
-        im->setIter(x, y, iter);
-        im->setFate(x, y, 0, fate);
-        im->setIndex(x, y, 0, index);
+        m_im->setIter(x, y, iter);
+        m_im->setFate(x, y, 0, fate);
+        m_im->setIndex(x, y, 0, index);
         rectangle(pixel, x, y, w, h);
     }
     else
     {
-        pixel = pf->recolor(im->getIndex(x, y, 0), fate, im->get(x, y));
+        pixel = m_pf->recolor(m_im->getIndex(x, y, 0), fate, m_im->get(x, y));
         rectangle(pixel, x, y, w, h);
     }
 }
@@ -506,9 +508,9 @@ void STFractWorker::qbox_row(int w, int y, int rsize, int drawsize)
 
 bool STFractWorker::needs_aa_calc(int x, int y)
 {
-    for (int i = 0; i < im->getNSubPixels(); ++i)
+    for (int i = 0; i < m_im->getNSubPixels(); ++i)
     {
-        if (im->getFate(x, y, i) == FATE_UNKNOWN)
+        if (m_im->getFate(x, y, i) == FATE_UNKNOWN)
         {
             return true;
         }
@@ -519,10 +521,10 @@ bool STFractWorker::needs_aa_calc(int x, int y)
 void STFractWorker::pixel_aa(int x, int y)
 {
     rgba_t pixel;
-    int iter = im->getIter(x, y);
+    int iter = m_im->getIter(x, y);
     // if aa type is fast, short-circuit some points
-    if (options->eaa == AA_FAST &&
-        x > 0 && x < im->Xres() - 1 && y > 0 && y < im->Yres() - 1)
+    if (m_options->eaa == AA_FAST &&
+        x > 0 && x < m_im->Xres() - 1 && y > 0 && y < m_im->Yres() - 1)
     {
         // check to see if this point is surrounded by others of the same colour
         // if so, don't bother recalculating
@@ -534,11 +536,11 @@ void STFractWorker::pixel_aa(int x, int y)
             isTheSame(iter, pcol, x, y + 1);
         if (bFlat)
         {
-            if (ff->debug_flags & DEBUG_DRAWING_STATS)
+            if (m_ff->debug_flags & DEBUG_DRAWING_STATS)
             {
                 printf("noaa %d %d\n", x, y);
             }
-            im->fill_subpixels(x, y);
+            m_im->fill_subpixels(x, y);
             return;
         }
     }
@@ -549,18 +551,18 @@ void STFractWorker::pixel_aa(int x, int y)
 bool STFractWorker::isNearlyFlat(int x, int y, int rsize)
 {
     rgba_t colors[2];
-    fate_t fate = im->getFate(x, y, 0);
+    fate_t fate = m_im->getFate(x, y, 0);
     const int MAXERROR = 3;
     // can we predict the top edge close enough?
-    colors[0] = im->get(x, y);             // topleft
-    colors[1] = im->get(x + rsize - 1, y); //topright
+    colors[0] = m_im->get(x, y);             // topleft
+    colors[1] = m_im->get(x + rsize - 1, y); //topright
     int x2;
     for (x2 = x + 1; x2 < x + rsize - 1; ++x2)
     {
-        if (im->getFate(x2, y, 0) != fate)
+        if (m_im->getFate(x2, y, 0) != fate)
             return false;
         rgba_t predicted = predict_color(colors, (double)(x2 - x) / rsize);
-        int diff = diff_colors(predicted, im->get(x2, y));
+        int diff = diff_colors(predicted, m_im->get(x2, y));
         if (diff > MAXERROR)
         {
             return false;
@@ -568,28 +570,28 @@ bool STFractWorker::isNearlyFlat(int x, int y, int rsize)
     }
     // how about the bottom edge?
     int y2 = y + rsize - 1;
-    colors[0] = im->get(x, y2);             // botleft
-    colors[1] = im->get(x + rsize - 1, y2); // botright
+    colors[0] = m_im->get(x, y2);             // botleft
+    colors[1] = m_im->get(x + rsize - 1, y2); // botright
     for (x2 = x + 1; x2 < x + rsize - 1; ++x2)
     {
-        if (im->getFate(x2, y2, 0) != fate)
+        if (m_im->getFate(x2, y2, 0) != fate)
             return false;
         rgba_t predicted = predict_color(colors, (double)(x2 - x) / rsize);
-        int diff = diff_colors(predicted, im->get(x2, y2));
+        int diff = diff_colors(predicted, m_im->get(x2, y2));
         if (diff > MAXERROR)
         {
             return false;
         }
     }
     // how about the left side?
-    colors[0] = im->get(x, y);
-    colors[1] = im->get(x, y + rsize - 1);
+    colors[0] = m_im->get(x, y);
+    colors[1] = m_im->get(x, y + rsize - 1);
     for (y2 = y + 1; y2 < y + rsize - 1; ++y2)
     {
-        if (im->getFate(x, y2, 0) != fate)
+        if (m_im->getFate(x, y2, 0) != fate)
             return false;
         rgba_t predicted = predict_color(colors, (double)(y2 - y) / rsize);
-        int diff = diff_colors(predicted, im->get(x, y2));
+        int diff = diff_colors(predicted, m_im->get(x, y2));
         if (diff > MAXERROR)
         {
             return false;
@@ -597,14 +599,14 @@ bool STFractWorker::isNearlyFlat(int x, int y, int rsize)
     }
     // and finally the right
     x2 = x + rsize - 1;
-    colors[0] = im->get(x2, y);
-    colors[1] = im->get(x2, y + rsize - 1);
+    colors[0] = m_im->get(x2, y);
+    colors[1] = m_im->get(x2, y + rsize - 1);
     for (y2 = y + 1; y2 < y + rsize - 1; ++y2)
     {
-        if (im->getFate(x2, y2, 0) != fate)
+        if (m_im->getFate(x2, y2, 0) != fate)
             return false;
         rgba_t predicted = predict_color(colors, (double)(y2 - y) / rsize);
-        int diff = diff_colors(predicted, im->get(x2, y2));
+        int diff = diff_colors(predicted, m_im->get(x2, y2));
         if (diff > MAXERROR)
         {
             return false;
@@ -624,16 +626,16 @@ void STFractWorker::interpolate_rectangle(int x, int y, int rsize)
 
 void STFractWorker::interpolate_row(int x, int y, int rsize)
 {
-    fate_t fate = im->getFate(x, y, 0);
+    fate_t fate = m_im->getFate(x, y, 0);
     rgba_t colors[2];
-    colors[0] = im->get(x, y);             // left
-    colors[1] = im->get(x + rsize - 1, y); //right
+    colors[0] = m_im->get(x, y);             // left
+    colors[1] = m_im->get(x + rsize - 1, y); //right
     int iters[2];
-    iters[0] = im->getIter(x, y);
-    iters[1] = im->getIter(x + rsize - 1, y);
+    iters[0] = m_im->getIter(x, y);
+    iters[1] = m_im->getIter(x + rsize - 1, y);
     int indexes[2];
-    indexes[0] = im->getIndex(x, y, 0);
-    indexes[1] = im->getIndex(x + rsize - 1, y, 0);
+    indexes[0] = m_im->getIndex(x, y, 0);
+    indexes[1] = m_im->getIndex(x + rsize - 1, y, 0);
     for (int x2 = x; x2 < x + rsize - 1; ++x2)
     {
         double factor = (double)(x2 - x) / rsize;
@@ -641,12 +643,12 @@ void STFractWorker::interpolate_row(int x, int y, int rsize)
         int predicted_iter = predict_iter(iters, factor);
         float predicted_index = predict_index(indexes, factor);
         //check_guess(x2,y,predicted_color,fate,predicted_iter,predicted_index);
-        im->put(x2, y, predicted_color);
-        im->setIter(x2, y, predicted_iter);
-        im->setFate(x2, y, 0, fate);
-        im->setIndex(x2, y, 0, predicted_index);
-        stats.s[PIXELS]++;
-        stats.s[PIXELS_SKIPPED]++;
+        m_im->put(x2, y, predicted_color);
+        m_im->setIter(x2, y, predicted_iter);
+        m_im->setFate(x2, y, 0, fate);
+        m_im->setIndex(x2, y, 0, predicted_index);
+        m_stats.s[PIXELS]++;
+        m_stats.s[PIXELS_SKIPPED]++;
     }
 }
 
@@ -687,7 +689,7 @@ void STFractWorker::box(int x, int y, int rsize)
     // if they are, we assume that the box is a solid colour and
     // don't calculate the interior points
     bool bFlat = true;
-    const int iter = im->getIter(x, y);
+    const int iter = m_im->getIter(x, y);
     const int pcol = Pixel2INT(x, y);
     // calculate top and bottom of box & check for flatness
     for (int x2 = x; x2 < x + rsize; ++x2)
@@ -709,9 +711,9 @@ void STFractWorker::box(int x, int y, int rsize)
     if (bFlat)
     {
         // just draw a solid rectangle
-        rgba_t pixel = im->get(x, y);
-        fate_t fate = im->getFate(x, y, 0);
-        float index = im->getIndex(x, y, 0);
+        rgba_t pixel = m_im->get(x, y);
+        fate_t fate = m_im->getFate(x, y, 0);
+        float index = m_im->getIndex(x, y, 0);
         rectangle_with_iter(pixel, fate, iter, index, x + 1, y + 1, rsize - 2, rsize - 2);
     }
     else
@@ -754,7 +756,7 @@ inline void STFractWorker::rectangle(
     {
         for (int j = x; j < x + w; j++)
         {
-            im->put(j, i, pixel);
+            m_im->put(j, i, pixel);
         }
     }
 }
@@ -764,15 +766,15 @@ inline void STFractWorker::check_guess(int x, int y, rgba_t pixel, fate_t fate, 
     // check if guess was correct
     if (true)
     {
-        dvec4 pos = ff->topleft + x * ff->deltax + y * ff->deltay;
+        dvec4 pos = m_ff->topleft + x * m_ff->deltax + y * m_ff->deltay;
         rgba_t tpixel;
         int titer;
         float tindex;
         fate_t tfate;
-        pf->calc(
-            pos.n, options->maxiter,
-            periodGuess(), options->period_tolerance,
-            options->warp_param,
+        m_pf->calc(
+            pos.n, m_options->maxiter,
+            periodGuess(), m_options->period_tolerance,
+            m_options->warp_param,
             x, y, 0,
             &tpixel, &titer, &tindex, &tfate);
         if (tpixel == pixel)
@@ -780,11 +782,11 @@ inline void STFractWorker::check_guess(int x, int y, rgba_t pixel, fate_t fate, 
         //	    iter == titer &&
         //	    fabs(index-tindex) < 1.0e-2)
         {
-            stats.s[PIXELS_SKIPPED_RIGHT]++;
+            m_stats.s[PIXELS_SKIPPED_RIGHT]++;
         }
         else
         {
-            stats.s[PIXELS_SKIPPED_WRONG]++;
+            m_stats.s[PIXELS_SKIPPED_WRONG]++;
         }
     }
 }
@@ -797,17 +799,17 @@ inline void STFractWorker::rectangle_with_iter(
     {
         for (int j = x; j < x + w; j++)
         {
-            if (ff->debug_flags & DEBUG_DRAWING_STATS)
+            if (m_ff->debug_flags & DEBUG_DRAWING_STATS)
             {
                 printf("guess %d %d %d %d\n", j, i, fate, iter);
             }
             //check_guess(j,i,pixel,fate,iter,index);
-            im->put(j, i, pixel);
-            im->setIter(j, i, iter);
-            im->setFate(j, i, 0, fate);
-            im->setIndex(j, i, 0, index);
-            stats.s[PIXELS]++;
-            stats.s[PIXELS_SKIPPED]++;
+            m_im->put(j, i, pixel);
+            m_im->setIter(j, i, iter);
+            m_im->setFate(j, i, 0, fate);
+            m_im->setIndex(j, i, 0, index);
+            m_stats.s[PIXELS]++;
+            m_stats.s[PIXELS_SKIPPED]++;
         }
     }
 }
@@ -836,10 +838,10 @@ bool STFractWorker::find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root)
 
         pos = eye + dist * look;
         //printf("%g %g %g %g\n", pos[0], pos[1], pos[2], pos[3]);
-        pf->calc(
-            pos.n, options->maxiter,
-            periodGuess(), options->period_tolerance,
-            options->warp_param,
+        m_pf->calc(
+            pos.n, m_options->maxiter,
+            periodGuess(), m_options->period_tolerance,
+            m_options->warp_param,
             x, y, 0,
             &pixel, &iter, &index, &fate);
         steps += 1;
@@ -860,9 +862,9 @@ bool STFractWorker::find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root)
     {
         d mid = (lastdist + dist) / 2.0;
         pos = eye + mid * look;
-        pf->calc(pos.n, options->maxiter,
-                 periodGuess(), options->period_tolerance,
-                 options->warp_param,
+        m_pf->calc(pos.n, m_options->maxiter,
+                 periodGuess(), m_options->period_tolerance,
+                 m_options->warp_param,
                  x, y, 0,
                  &pixel, &iter, &index, &fate);
         if (fate != 0) // FIXME

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -7,13 +7,12 @@
 #include "model/colormap.h"
 #include "model/image.h"
 #include "model/site.h"
-#include "model/pointfunc.h"
 #include "model/fractfunc.h"
 
 #include "pf.h"
 
 STFractWorker::STFractWorker(pf_obj *pfo, ColorMap *cmap, IImage *im_, IFractalSite *site) noexcept:
-    ff{nullptr}, im{im_}, lastIter{0}, m_ok{true}
+    ff{nullptr}, im{im_}, lastIter{0}
 {
     pf = std::unique_ptr<pointFunc>(pointFunc::create(pfo, cmap, site));
     if (!pf)
@@ -23,13 +22,10 @@ STFractWorker::STFractWorker(pf_obj *pfo, ColorMap *cmap, IImage *im_, IFractalS
 }
 
 STFractWorker::STFractWorker(STFractWorker &&original) noexcept:
-    ff{original.ff}, im{original.im}, pf{std::move(original.pf)},
-    stats{original.stats}, lastIter{original.lastIter}, m_ok{original.m_ok}
+    ff{original.ff}, im{original.im}, pf{std::move(original.pf)}, lastIter{original.lastIter}
 {
-}
-
-STFractWorker::~STFractWorker()
-{
+    this->m_ok = original.m_ok;
+    this->stats = original.stats;
 }
 
 void STFractWorker::set_fractFunc(fractFunc *ff_)

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -168,23 +168,16 @@ const pixel_stat_t &STFractWorker::get_stats() const
     return stats;
 }
 
-inline int STFractWorker::RGB2INT(int x, int y)
+inline int STFractWorker::Pixel2INT(int x, int y)
 {
-    rgba_t pixel = im->get(x, y);
-    return Pixel2INT(pixel);
-}
-
-inline int STFractWorker::Pixel2INT(rgba_t pixel)
-{
-    int ret = (pixel.r << 16) | (pixel.g << 8) | pixel.b;
-    return ret;
+    return static_cast<int>(im->get(x, y));
 }
 
 inline bool STFractWorker::isTheSame(int targetIter, int targetCol, int x, int y)
 {
     // does this point have the target # of iterations?
     // does it have the same colour too?
-    if ((im->getIter(x, y) == targetIter) && (RGB2INT(x, y) == targetCol)) {
+    if ((im->getIter(x, y) == targetIter) && (Pixel2INT(x, y) == targetCol)) {
         return true;
     }
     return false;
@@ -537,7 +530,7 @@ void STFractWorker::pixel_aa(int x, int y)
     {
         // check to see if this point is surrounded by others of the same colour
         // if so, don't bother recalculating
-        const int pcol = RGB2INT(x, y);
+        const int pcol = Pixel2INT(x, y);
         const bool bFlat =
             isTheSame(iter, pcol, x, y - 1) &&
             isTheSame(iter, pcol, x - 1, y) &&
@@ -699,7 +692,7 @@ void STFractWorker::box(int x, int y, int rsize)
     // don't calculate the interior points
     bool bFlat = true;
     const int iter = im->getIter(x, y);
-    const int pcol = RGB2INT(x, y);
+    const int pcol = Pixel2INT(x, y);
     // calculate top and bottom of box & check for flatness
     for (int x2 = x; x2 < x + rsize; ++x2)
     {
@@ -786,7 +779,7 @@ inline void STFractWorker::check_guess(int x, int y, rgba_t pixel, fate_t fate, 
             options->warp_param,
             x, y, 0,
             &tpixel, &titer, &tindex, &tfate);
-        if (Pixel2INT(tpixel) == Pixel2INT(pixel))
+        if (tpixel == pixel)
         //	    fate == tfate &&
         //	    iter == titer &&
         //	    fabs(index-tindex) < 1.0e-2)

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -22,14 +22,6 @@ STFractWorker::STFractWorker(pf_obj *pfo, ColorMap *cmap, IImage *im, IFractalSi
     }
 }
 
-STFractWorker::STFractWorker(STFractWorker &&original) noexcept:
-    m_options{original.m_options}, m_ff{original.m_ff},
-    m_im{original.m_im}, m_pf{std::move(original.m_pf)}, m_lastPointIters{original.m_lastPointIters}
-{
-    m_ok = original.m_ok;
-    m_stats = original.m_stats;
-}
-
 void STFractWorker::set_fractFunc(fractFunc *ff_)
 {
     m_ff = ff_;

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -9,6 +9,7 @@
 #include "model/image.h"
 #include "model/site.h"
 #include "model/fractfunc.h"
+#include "model/calcoptions.h"
 
 #include "pf.h"
 

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -37,51 +37,47 @@ void STFractWorker::set_fractFunc(fractFunc *ff_)
 /* we're in a worker thread */
 void STFractWorker::work(job_info_t &tdata)
 {
-    int nRows = 0;
-    int x = tdata.x;
-    int y = tdata.y;
-    int param = tdata.param;
-    int param2 = tdata.param2;
-    job_type_t job = tdata.job;
     if (ff->try_finished_cond())
     {
         // interrupted - just return without doing anything
         // this is less efficient than clearing the queue but easier
         return;
     }
+    int nRows = 0;
     /* carry them out */
-    switch (job)
+    switch (tdata.job)
     {
     case JOB_BOX:
         //printf("BOX(%d,%d,%d) [%x]\n",x,y,param,(unsigned int)pthread_self());
-        box(x, y, param);
-        nRows = param;
+        box(tdata.x, tdata.y, tdata.param);
+        nRows = tdata.param;
         break;
     case JOB_ROW:
         //printf("ROW(%d,%d,%d) [%x]\n",x,y,param,(unsigned int)pthread_self());
-        row(x, y, param);
+        row(tdata.x, tdata.y, tdata.param);
         nRows = 1;
         break;
     case JOB_BOX_ROW:
         //printf("BXR(%d,%d,%d) [%x]\n",x,y,param,(unsigned int)pthread_self());
-        box_row(x, y, param);
-        nRows = param;
+        box_row(tdata.x, tdata.y, tdata.param);
+        nRows = tdata.param;
         break;
     case JOB_ROW_AA:
         //printf("RAA(%d,%d,%d) [%x]\n",x,y,param,(unsigned int)pthread_self());
-        row_aa(x, y, param);
+        row_aa(tdata.x, tdata.y, tdata.param);
         nRows = 1;
         break;
     case JOB_QBOX_ROW:
         //printf("QBR(%d,%d,%d,%d) [%x]\n",x,y,param,param2,(unsigned int)pthread_self());
-        qbox_row(x, y, param, param2);
-        nRows = param;
+        qbox_row(tdata.x, tdata.y, tdata.param, tdata.param2);
+        nRows = tdata.param;
         break;
     default:
-        printf("Unknown job id %d ignored\n", (int)job);
+        printf("Unknown job id %d ignored\n", static_cast<int>(tdata.job));
     }
-    ff->image_changed(0, y, im->Xres(), y + nRows);
-    ff->progress_changed((float)y / (float)im->Yres());
+    ff->image_changed(0, tdata.y, im->Xres(), tdata.y + nRows);
+    const float new_progress = static_cast<float>(tdata.y) / static_cast<float>(im->Yres());
+    ff->progress_changed(new_progress);
 }
 
 void STFractWorker::row_aa(int x, int y, int w)

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -16,7 +16,7 @@
 void STFractWorker::set_fractFunc(fractFunc *ff_)
 {
     m_ff = ff_;
-    m_options = &ff_->options;
+    m_options = &ff_->m_options;
 }
 
 /* we're in a worker thread */
@@ -175,7 +175,7 @@ rgba_t STFractWorker::antialias(int x, int y)
     fate_t fate;
     int single_iters = m_im->getIter(x, y);
     int checkPeriod = periodGuess(single_iters);
-    if (m_ff->debug_flags & DEBUG_DRAWING_STATS)
+    if (m_ff->m_debug_flags & DEBUG_DRAWING_STATS)
     {
         printf("doaa %d %d\n", x, y);
     }
@@ -440,7 +440,7 @@ void STFractWorker::pixel(int x, int y, int w, int h)
         break;
         }
         periodSet(&iter);
-        if (m_ff->debug_flags & DEBUG_DRAWING_STATS)
+        if (m_ff->m_debug_flags & DEBUG_DRAWING_STATS)
         {
             printf("pixel %d %d %d %d\n", x, y, fate, iter);
         }
@@ -518,7 +518,7 @@ void STFractWorker::pixel_aa(int x, int y)
             isTheSame(iter, pcol, x, y + 1);
         if (bFlat)
         {
-            if (m_ff->debug_flags & DEBUG_DRAWING_STATS)
+            if (m_ff->m_debug_flags & DEBUG_DRAWING_STATS)
             {
                 printf("noaa %d %d\n", x, y);
             }
@@ -781,7 +781,7 @@ inline void STFractWorker::rectangle_with_iter(
     {
         for (int j = x; j < x + w; j++)
         {
-            if (m_ff->debug_flags & DEBUG_DRAWING_STATS)
+            if (m_ff->m_debug_flags & DEBUG_DRAWING_STATS)
             {
                 printf("guess %d %d %d %d\n", j, i, fate, iter);
             }

--- a/fract4d/c/model/calcfunc.cpp
+++ b/fract4d/c/model/calcfunc.cpp
@@ -20,7 +20,7 @@ void calc(
     assert(im && site && cmap && pfo && params);
 
     std::unique_ptr<IFractWorker> worker {IFractWorker::create(options.nThreads, pfo, cmap, im, site)};
-    if (worker && worker->ok())
+    if (worker)
     {
         fractFunc ff(
             options,

--- a/fract4d/c/model/calcfunc.cpp
+++ b/fract4d/c/model/calcfunc.cpp
@@ -7,48 +7,31 @@
 #include "model/fractfunc.h"
 #include "model/image.h"
 
+
 void calc(
+    calc_options options,
     d *params,
-    int eaa,
-    int maxiter,
-    int nThreads,
     pf_obj *pfo,
     ColorMap *cmap,
-    bool auto_deepen,
-    bool auto_tolerance,
-    double tolerance,
-    bool yflip,
-    bool periodicity,
-    bool dirty,
-    int debug_flags,
-    render_type_t render_type,
-    int warp_param,
+    IFractalSite *site,
     IImage *im,
-    IFractalSite *site)
+    int debug_flags)
 {
     assert(im && site && cmap && pfo && params);
 
-    std::unique_ptr<IFractWorker> worker {IFractWorker::create(nThreads, pfo, cmap, im, site)};
+    std::unique_ptr<IFractWorker> worker {IFractWorker::create(options.nThreads, pfo, cmap, im, site)};
     if (worker && worker->ok())
     {
         fractFunc ff(
+            options,
             params,
-            eaa,
-            maxiter,
-            nThreads,
-            auto_deepen,
-            auto_tolerance,
-            tolerance,
-            yflip,
-            periodicity,
-            render_type,
-            warp_param,
             worker.get(),
             im,
-            site);
+            site
+        );
 
         ff.set_debug_flags(debug_flags);
-        if (dirty)
+        if (options.dirty)
         {
             im->clear();
         }

--- a/fract4d/c/model/calcfunc.cpp
+++ b/fract4d/c/model/calcfunc.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <memory>
 
 #include "calcfunc.h"
 
@@ -25,10 +26,9 @@ void calc(
     IImage *im,
     IFractalSite *site)
 {
-    assert(NULL != im && NULL != site &&
-           NULL != cmap && NULL != pfo && NULL != params);
-    IFractWorker *worker = IFractWorker::create(nThreads, pfo, cmap, im, site);
+    assert(im && site && cmap && pfo && params);
 
+    std::unique_ptr<IFractWorker> worker {IFractWorker::create(nThreads, pfo, cmap, im, site)};
     if (worker && worker->ok())
     {
         fractFunc ff(
@@ -43,7 +43,7 @@ void calc(
             periodicity,
             render_type,
             warp_param,
-            worker,
+            worker.get(),
             im,
             site);
 
@@ -54,5 +54,4 @@ void calc(
         }
         ff.draw_all();
     }
-    delete worker;
 }

--- a/fract4d/c/model/calcfunc.h
+++ b/fract4d/c/model/calcfunc.h
@@ -1,7 +1,7 @@
 #ifndef __CALCFUNC_H_INCLUDED__
 #define __CALCFUNC_H_INCLUDED__
 
-#include "model/enums.h"
+#include "model/calcoptions.h"
 
 typedef struct s_pf_data pf_obj;
 typedef double d;
@@ -16,23 +16,14 @@ extern "C"
 #endif
 
     void calc(
+        calc_options,
         d *params,
-        int eaa,
-        int maxiter,
-        int nThreads_,
-        pf_obj *pfo,
-        ColorMap *cmap,
-        bool auto_deepen,
-        bool auto_tolerance,
-        double tolerance,
-        bool yflip,
-        bool periodicity,
-        bool dirty,
-        int debug_flags,
-        render_type_t render_type,
-        int warp_param,
-        IImage *im,
-        IFractalSite *site);
+        pf_obj *,
+        ColorMap *,
+        IFractalSite *,
+        IImage *,
+        int debug_flags
+    );
 
 #ifdef __cplusplus
 }

--- a/fract4d/c/model/calcoptions.h
+++ b/fract4d/c/model/calcoptions.h
@@ -1,0 +1,23 @@
+#ifndef __CALCOPTIONS_H_INCLUDED__
+#define __CALCOPTIONS_H_INCLUDED__
+
+#include "model/enums.h"
+
+struct calc_options
+{
+    int
+        eaa = AA_NONE,
+        maxiter =  1024,
+        nThreads = 1,
+        auto_deepen = false,
+        yflip = false,
+        periodicity = true,
+        dirty = 1,
+        auto_tolerance = false,
+        asynchronous = false,
+        warp_param = -1;
+    double period_tolerance = 1.0E-9;
+    render_type_t render_type = RENDER_TWO_D;
+};
+
+#endif

--- a/fract4d/c/model/calcoptions.h
+++ b/fract4d/c/model/calcoptions.h
@@ -14,7 +14,7 @@ struct calc_options
         periodicity = true, // enables "period checking" technique to find values which vary within an interval before reaching maxiter
         dirty = 1, // clears the image fate and iters buffers
         auto_tolerance = false, // dinamically adjust period_tolerance value (based on statistics of the current process)
-        warp_param = -1; // index of the param to be wrapped
+        warp_param = -1; // index of the param to be warped
     double period_tolerance = 1.0E-9; // value used by the preiod checking technique
     render_type_t render_type = RENDER_TWO_D; // redenring mode, 2d as default (3d is also supported but experimental)
 };

--- a/fract4d/c/model/calcoptions.h
+++ b/fract4d/c/model/calcoptions.h
@@ -6,18 +6,17 @@
 struct calc_options
 {
     int
-        eaa = AA_NONE,
-        maxiter =  1024,
-        nThreads = 1,
-        auto_deepen = false,
-        yflip = false,
-        periodicity = true,
-        dirty = 1,
-        auto_tolerance = false,
-        asynchronous = false,
-        warp_param = -1;
-    double period_tolerance = 1.0E-9;
-    render_type_t render_type = RENDER_TWO_D;
+        eaa = AA_NONE, // antialiasing level
+        maxiter =  1024, // max iterations taken per point
+        nThreads = 1, // this traduces into number of threads/workers created in the threadpool
+        auto_deepen = false, // dinamically adjust the maxiter value (based on statistics of the current process)
+        yflip = false, // flip the image on the y axis
+        periodicity = true, // enables "period checking" technique to find values which vary within an interval before reaching maxiter
+        dirty = 1, // clears the image fate and iters buffers
+        auto_tolerance = false, // dinamically adjust period_tolerance value (based on statistics of the current process)
+        warp_param = -1; // index of the param to be wrapped
+    double period_tolerance = 1.0E-9; // value used by the preiod checking technique
+    render_type_t render_type = RENDER_TWO_D; // redenring mode, 2d as default (3d is also supported but experimental)
 };
 
 #endif

--- a/fract4d/c/model/color.h
+++ b/fract4d/c/model/color.h
@@ -1,11 +1,19 @@
-
 #ifndef COLOR_H_
 #define COLOR_H_
 
 struct s_rgba
 {
     unsigned char r,g,b,a;
+
+    inline explicit operator int() const {
+        return (r << 16) | (g << 8) | b;
+    }
 };
+
+inline bool operator== (const s_rgba& a, const s_rgba& b) {
+    // according to the original implementation "a" is not considered in the comparison
+    return a.r == b.r && a.g == b.g && a.b == b.b;
+}
 
 typedef struct s_rgba rgba_t;
 

--- a/fract4d/c/model/fractfunc.cpp
+++ b/fract4d/c/model/fractfunc.cpp
@@ -31,17 +31,6 @@ dvec4 test_eye_vector(double *params, double dist)
     return mat[VZ] * -dist;
 }
 
-double gettimediff(struct timeval &startTime, struct timeval &endTime)
-{
-    long int diff_usec = endTime.tv_usec - startTime.tv_usec;
-    if (diff_usec < 0)
-    {
-        endTime.tv_sec -= 1;
-        diff_usec = 1000000 + diff_usec;
-    }
-    return (double)(endTime.tv_sec - startTime.tv_sec) + (double)diff_usec / 1000000.0;
-}
-
 fractFunc::fractFunc(
     d *params_,
     int eaa_,
@@ -58,12 +47,12 @@ fractFunc::fractFunc(
     IImage *im_,
     IFractalSite *site_)
 {
+
     site = site_;
     im = im_;
     ok = true;
     debug_flags = 0;
     render_type = render_type_;
-    //printf("render type %d\n", render_type);
     worker = fw;
     params = params_;
     eaa = eaa_;
@@ -74,12 +63,9 @@ fractFunc::fractFunc(
     period_tolerance = period_tolerance_;
     periodicity = periodicity_;
     warp_param = warp_param_;
+
     set_progress_range(0.0, 1.0);
-    /*
-    printf("(%d,%d,%d,%d,%d,%d)\n",
-	   im->Xres(), im->Yres(), im->totalXres(), im->totalYres(),
-	   im->Xoffset(), im->Yoffset());
-    */
+
     dvec4 center = dvec4(
         params[XCENTER], params[YCENTER],
         params[ZCENTER], params[WCENTER]);
@@ -267,7 +253,6 @@ void fractFunc::draw_all()
     float minp = 0.0, maxp = 0.3;
     draw(16, 16, minp, maxp);
 
-    minp = 0.5;
     maxp = (eaa == AA_NONE ? 0.9 : 0.5);
     int improvement_flags;
     while ((improvement_flags = updateiters()) & SHOULD_IMPROVE)
@@ -324,8 +309,7 @@ void fractFunc::draw_all()
     if (debug_flags & DEBUG_TIMING)
     {
         std::time(&endTime);
-        double diff = std::difftime(startTime, endTime);
-        printf("time:%g\n", diff);
+        printf("time:%g\n", std::difftime(startTime, endTime));
     }
 }
 

--- a/fract4d/c/model/fractfunc.cpp
+++ b/fract4d/c/model/fractfunc.cpp
@@ -4,9 +4,9 @@
 #include <cassert>
 
 #include "fractfunc.h"
-
 #include "model/image.h"
 
+// produces the scaled rotation matrix from the params
 dmat4 rotated_matrix(double *params)
 {
     d one = d(1.0);
@@ -24,7 +24,6 @@ dmat4 rotated_matrix(double *params)
 // The eye vector is the line between the center of the screen and the
 // point where the user's eye is deemed to be. It's effectively the line
 // perpendicular to the screen in the -Z direction, scaled by the "eye distance"
-
 dvec4 test_eye_vector(double *params, double dist)
 {
     dmat4 mat = rotated_matrix(params);
@@ -45,31 +44,17 @@ fractFunc::fractFunc(
     int warp_param_,
     IFractWorker *fw,
     IImage *im_,
-    IFractalSite *site_)
+    IFractalSite *site_):
+    eaa{eaa_}, maxiter{maxiter_}, nThreads{nThreads_}, auto_deepen{auto_deepen_},
+    auto_tolerance{auto_tolerance_}, periodicity{periodicity_}, period_tolerance{period_tolerance_},
+    debug_flags{0}, render_type{render_type_}, warp_param{warp_param_}, params{params_},
+    im{im_}, worker{fw}, site{site_}, last_update_y{0}, min_progress{0.0f}, delta_progress{1.0f}
 {
-
-    site = site_;
-    im = im_;
-    ok = true;
-    debug_flags = 0;
-    render_type = render_type_;
-    worker = fw;
-    params = params_;
-    eaa = eaa_;
-    maxiter = maxiter_;
-    nThreads = nThreads_;
-    auto_deepen = auto_deepen_;
-    auto_tolerance = auto_tolerance_;
-    period_tolerance = period_tolerance_;
-    periodicity = periodicity_;
-    warp_param = warp_param_;
-
-    set_progress_range(0.0, 1.0);
-
     dvec4 center = dvec4(
         params[XCENTER], params[YCENTER],
         params[ZCENTER], params[WCENTER]);
-    rot = rotated_matrix(params);
+
+    dmat4 rot = rotated_matrix(params);
 
     eye_point = center + rot[VZ] * -10.0; // FIXME add eye distance parameter
 
@@ -99,8 +84,6 @@ fractFunc::fractFunc(
     aa_topleft = topleft - (delta_aa_y + delta_aa_x) / 2.0;
 
     worker->set_fractFunc(this);
-
-    last_update_y = 0;
 }
 
 bool fractFunc::update_image(int i)

--- a/fract4d/c/model/fractfunc.cpp
+++ b/fract4d/c/model/fractfunc.cpp
@@ -31,15 +31,15 @@ dvec4 test_eye_vector(double *params, double dist)
 }
 
 fractFunc::fractFunc(
-    calc_options options_,
-    d *params_,
+    calc_options options,
+    d *params,
     IFractWorker *fw,
-    IImage *im_,
-    IFractalSite *site_):
-    debug_flags{0},
-    options{options_}, params{params_},
-    im{im_}, worker{fw}, site{site_},
-    last_update_y{0}, min_progress{0.0f}, delta_progress{1.0f}
+    IImage *im,
+    IFractalSite *site):
+    m_options{options},
+    m_params{params},
+    m_im{im}, m_worker{fw}, m_site{site},
+    m_delta_progress{1.0f}
 {
     const dvec4 center = dvec4(
         params[XCENTER], params[YCENTER],
@@ -74,7 +74,7 @@ fractFunc::fractFunc(
     // antialias: offset to middle of top left quadrant of pixel
     aa_topleft = topleft - (delta_aa_y + delta_aa_x) / 2.0;
 
-    worker->set_fractFunc(this);
+    m_worker->set_fractFunc(this);
 }
 
 bool fractFunc::update_image(int i)
@@ -82,10 +82,10 @@ bool fractFunc::update_image(int i)
     const auto done = try_finished_cond();
     if (!done)
     {
-        image_changed(0, last_update_y, im->Xres(), i);
-        progress_changed(static_cast<float>(i) / static_cast<float>(im->Yres()));
+        image_changed(0, m_last_update_y, m_im->Xres(), i);
+        progress_changed(static_cast<float>(i) / static_cast<float>(m_im->Yres()));
     }
-    last_update_y = i;
+    m_last_update_y = i;
     return done;
 }
 
@@ -94,8 +94,8 @@ int fractFunc::updateiters()
 {
     int flags = 0;
     // add up all the subtotals
-    const pixel_stat_t &stats = worker->get_stats();
-    if (options.auto_deepen)
+    const pixel_stat_t &stats = m_worker->get_stats();
+    if (m_options.auto_deepen)
     {
         const double doublepercent = stats.better_depth_ratio() * AUTO_DEEPEN_FREQUENCY * 100;
         const double halfpercent = stats.worse_depth_ratio() * AUTO_DEEPEN_FREQUENCY * 100;
@@ -105,14 +105,14 @@ int fractFunc::updateiters()
             // quelle horreur!
             flags |= SHOULD_DEEPEN;
         }
-        else if (doublepercent == 0.0 && halfpercent < 0.5 && options.maxiter > 32)
+        else if (doublepercent == 0.0 && halfpercent < 0.5 && m_options.maxiter > 32)
         {
             // less than .5% would be wrong if we used half as many iters
             // therefore we are working too hard!
             flags |= SHOULD_SHALLOWEN;
         }
     }
-    if (options.auto_tolerance)
+    if (m_options.auto_tolerance)
     {
         const double tightenpercent = stats.better_tolerance_ratio() * AUTO_DEEPEN_FREQUENCY * 100;
         const double loosenpercent = stats.worse_tolerance_ratio() * AUTO_DEEPEN_FREQUENCY * 100;
@@ -120,7 +120,7 @@ int fractFunc::updateiters()
         {
             flags |= SHOULD_TIGHTEN;
         }
-        else if (tightenpercent == 0.0 && loosenpercent < 0.5 && options.period_tolerance < 1.0E-4)
+        else if (tightenpercent == 0.0 && loosenpercent < 0.5 && m_options.period_tolerance < 1.0E-4)
         {
             flags |= SHOULD_LOOSEN;
         }
@@ -130,8 +130,8 @@ int fractFunc::updateiters()
 
 void fractFunc::draw_aa(float min_progress, float max_progress)
 {
-    const auto w = im->Xres();
-    const auto h = im->Yres();
+    const auto w = m_im->Xres();
+    const auto h = m_im->Yres();
 
     reset_counts();
 
@@ -150,11 +150,11 @@ void fractFunc::draw_aa(float min_progress, float max_progress)
             min_progress + delta * (i + 1));
 
         reset_progress(0.0);
-        last_update_y = 0;
+        m_last_update_y = 0;
 
         for (int y = i; y < h; y += 2)
         {
-            worker->row_aa(0, y, w);
+            m_worker->row_aa(0, y, w);
             if (update_image(y))
             {
                 break;
@@ -167,13 +167,13 @@ void fractFunc::draw_aa(float min_progress, float max_progress)
 
 void fractFunc::reset_counts()
 {
-    worker->reset_counts();
+    m_worker->reset_counts();
 }
 
 void fractFunc::reset_progress(float progress)
 {
-    worker->flush();
-    image_changed(0, 0, im->Xres(), im->Yres());
+    m_worker->flush();
+    image_changed(0, 0, m_im->Xres(), m_im->Yres());
     progress_changed(progress);
 }
 
@@ -181,18 +181,18 @@ void fractFunc::reset_progress(float progress)
 // image got deeper
 void fractFunc::clear_in_fates()
 {
-    const auto w = im->Xres();
-    const auto h = im->Yres();
+    const auto w = m_im->Xres();
+    const auto h = m_im->Yres();
     // FIXME can end up with some subpixels known and some unknown
     for (auto y = 0; y < h; ++y)
     {
         for (auto x = 0; x < w; ++x)
         {
-            for (auto n = 0; n < im->getNSubPixels(); ++n)
+            for (auto n = 0; n < m_im->getNSubPixels(); ++n)
             {
-                if (im->getFate(x, y, n) & FATE_INSIDE)
+                if (m_im->getFate(x, y, n) & FATE_INSIDE)
                 {
-                    im->setFate(x, y, n, FATE_UNKNOWN);
+                    m_im->setFate(x, y, n, FATE_UNKNOWN);
                 }
             }
         }
@@ -202,7 +202,7 @@ void fractFunc::clear_in_fates()
 void fractFunc::draw_all()
 {
     std::time_t startTime, endTime;
-    if (debug_flags & DEBUG_TIMING)
+    if (m_debug_flags & DEBUG_TIMING)
     {
         std::time(&startTime);
     }
@@ -216,7 +216,7 @@ void fractFunc::draw_all()
     float minp = 0.0, maxp = 0.3;
     draw(16, 16, minp, maxp);
 
-    maxp = options.eaa == AA_NONE ? 0.9 : 0.5;
+    maxp = m_options.eaa == AA_NONE ? 0.9 : 0.5;
     int improvement_flags;
     while ((improvement_flags = updateiters()) & SHOULD_IMPROVE)
     {
@@ -226,22 +226,22 @@ void fractFunc::draw_all()
 
         if (improvement_flags & SHOULD_DEEPEN)
         {
-            options.maxiter *= 2;
-            iters_changed(options.maxiter);
+            m_options.maxiter *= 2;
+            iters_changed(m_options.maxiter);
             status_changed(GF4D_FRACTAL_DEEPENING);
             clear_in_fates();
         }
         if (improvement_flags & SHOULD_TIGHTEN)
         {
-            options.period_tolerance /= 10.0;
-            tolerance_changed(options.period_tolerance);
+            m_options.period_tolerance /= 10.0;
+            tolerance_changed(m_options.period_tolerance);
             status_changed(GF4D_FRACTAL_TIGHTENING);
             clear_in_fates();
         }
         draw(16, 1, minp, maxp);
     }
 
-    if (options.eaa > AA_NONE)
+    if (m_options.eaa > AA_NONE)
     {
         status_changed(GF4D_FRACTAL_ANTIALIASING);
         draw_aa(maxp, 1.0);
@@ -256,20 +256,20 @@ void fractFunc::draw_all()
     // aa pass makes the image shallower, which is distracting
     if (improvement_flags & SHOULD_SHALLOWEN)
     {
-        options.maxiter /= 2;
-        iters_changed(options.maxiter);
+        m_options.maxiter /= 2;
+        iters_changed(m_options.maxiter);
     }
     if (improvement_flags & SHOULD_LOOSEN)
     {
-        options.period_tolerance *= 10.0;
-        tolerance_changed(options.period_tolerance);
+        m_options.period_tolerance *= 10.0;
+        tolerance_changed(m_options.period_tolerance);
     }
 #endif
 
     progress_changed(0.0);
     status_changed(GF4D_FRACTAL_DONE);
 
-    if (debug_flags & DEBUG_TIMING)
+    if (m_debug_flags & DEBUG_TIMING)
     {
         std::time(&endTime);
         printf("time:%g\n", std::difftime(startTime, endTime));
@@ -278,20 +278,20 @@ void fractFunc::draw_all()
 
 void fractFunc::draw(int rsize, int drawsize, float min_progress, float max_progress)
 {
-    if (debug_flags & DEBUG_QUICK_TRACE)
+    if (m_debug_flags & DEBUG_QUICK_TRACE)
     {
-        printf("drawing: %d\n", options.render_type);
+        printf("drawing: %d\n", m_options.render_type);
     }
     reset_counts();
 
     // init RNG based on time before generating image
     std::srand(static_cast<unsigned int>(std::time(nullptr)));
 
-    const auto w = im->Xres();
-    const auto h = im->Yres();
+    const auto w = m_im->Xres();
+    const auto h = m_im->Yres();
 
     /* reset progress indicator & clear screen */
-    last_update_y = 0;
+    m_last_update_y = 0;
     reset_progress(min_progress);
     float mid_progress = (max_progress + min_progress) / 2.0;
     set_progress_range(min_progress, mid_progress);
@@ -300,24 +300,24 @@ void fractFunc::draw(int rsize, int drawsize, float min_progress, float max_prog
     int y = 0;
     while(y < h) {
         if ((h - y) > rsize) {
-            worker->qbox_row(w, y, rsize, drawsize);
+            m_worker->qbox_row(w, y, rsize, drawsize);
             y += rsize;
         } else {
-            worker->row(0, y, w);
+            m_worker->row(0, y, w);
             y++;
         }
         if (update_image(y)) {
             break;
         }
     }
-    last_update_y = 0;
+    m_last_update_y = 0;
     reset_progress(0.0);
     set_progress_range(mid_progress, max_progress);
 
     // fill in gaps in the rsize-blocks
     for (auto y = 0; y < h - rsize; y += rsize)
     {
-        worker->box_row(w, y, rsize);
+        m_worker->box_row(w, y, rsize);
         if (update_image(y))
         {
             break;
@@ -331,7 +331,7 @@ void fractFunc::draw(int rsize, int drawsize, float min_progress, float max_prog
 
 void fractFunc::set_debug_flags(int debug_flags)
 {
-    this->debug_flags = debug_flags;
+    m_debug_flags = debug_flags;
 }
 
 dvec4 fractFunc::vec_for_point(double x, double y)
@@ -344,7 +344,7 @@ dvec4 fractFunc::vec_for_point(double x, double y)
 
 void fractFunc::set_progress_range(float min, float max)
 {
-    min_progress = min;
-    delta_progress = max - min;
-    assert(delta_progress > 0.0);
+    m_min_progress = min;
+    m_delta_progress = max - min;
+    assert(m_delta_progress > 0.0);
 }

--- a/fract4d/c/model/fractfunc.cpp
+++ b/fract4d/c/model/fractfunc.cpp
@@ -220,24 +220,22 @@ void fractFunc::draw_all()
     int improvement_flags;
     while ((improvement_flags = updateiters()) & SHOULD_IMPROVE)
     {
-        float delta = (1.0 - maxp) / 3.0;
+        const float delta = (1.0 - maxp) / 3.0;
         minp = maxp;
         maxp = maxp + delta;
-
         if (improvement_flags & SHOULD_DEEPEN)
         {
             m_options.maxiter *= 2;
             iters_changed(m_options.maxiter);
             status_changed(GF4D_FRACTAL_DEEPENING);
-            clear_in_fates();
         }
         if (improvement_flags & SHOULD_TIGHTEN)
         {
             m_options.period_tolerance /= 10.0;
             tolerance_changed(m_options.period_tolerance);
             status_changed(GF4D_FRACTAL_TIGHTENING);
-            clear_in_fates();
         }
+        clear_in_fates();
         draw(16, 1, minp, maxp);
     }
 

--- a/fract4d/c/model/fractfunc.cpp
+++ b/fract4d/c/model/fractfunc.cpp
@@ -36,10 +36,13 @@ fractFunc::fractFunc(
     IFractWorker *fw,
     IImage *im,
     IFractalSite *site):
+    m_debug_flags{0},
     m_options{options},
     m_params{params},
     m_im{im}, m_worker{fw}, m_site{site},
-    m_delta_progress{1.0f}
+    m_last_update_y{0},
+    m_min_progress{0.0f}, m_delta_progress{1.0f},
+    m_stats{}
 {
     const dvec4 center = dvec4(
         params[XCENTER], params[YCENTER],

--- a/fract4d/c/model/fractfunc.cpp
+++ b/fract4d/c/model/fractfunc.cpp
@@ -38,7 +38,6 @@ fractFunc::fractFunc(
     IFractalSite *site):
     m_debug_flags{0},
     m_options{options},
-    m_params{params},
     m_im{im}, m_worker{fw}, m_site{site},
     m_last_update_y{0},
     m_min_progress{0.0f}, m_delta_progress{1.0f},

--- a/fract4d/c/model/fractfunc.h
+++ b/fract4d/c/model/fractfunc.h
@@ -6,6 +6,7 @@
 #include "model/site.h"
 #include "model/stats.h"
 #include "model/enums.h"
+#include "model/calcoptions.h"
 
 class IImage;
 
@@ -30,23 +31,14 @@ class fractFunc
 {
 public:
     fractFunc(
+        calc_options,
         d *params,
-        int eaa,
-        int maxiter,
-        int nThreads_,
-        bool auto_deepen,
-        bool auto_tolerance,
-        double period_tolerance,
-        bool yflip,
-        bool periodicity,
-        render_type_t render_type,
-        int warp_param,
-        IFractWorker *fw,
-        IImage *_im,
-        IFractalSite *_site);
+        IFractWorker *,
+        IImage *,
+        IFractalSite *);
     ~fractFunc(){};
     // additional flags controlling debugging & profiling options
-    void set_debug_flags(int debug_flags);
+    void set_debug_flags(int);
     void draw_all();
 
     // a vector from the eye through the pixel at (x,y)
@@ -112,16 +104,8 @@ private:
     };
 
     // params from ctor
-    int eaa;
-    int maxiter;
-    int nThreads;
-    bool auto_deepen;
-    bool auto_tolerance;
-    bool periodicity;
-    double period_tolerance;
     int debug_flags;
-    render_type_t render_type;
-    int warp_param;
+    calc_options options;
     d *params;
     IImage *im;
     IFractWorker *worker;

--- a/fract4d/c/model/fractfunc.h
+++ b/fract4d/c/model/fractfunc.h
@@ -48,33 +48,33 @@ public:
     // callback wrappers
     inline void iters_changed(int iters)
     {
-        site->iters_changed(iters);
+        m_site->iters_changed(iters);
     }
     inline void tolerance_changed(double tolerance)
     {
-        site->tolerance_changed(tolerance);
+        m_site->tolerance_changed(tolerance);
     }
     inline void image_changed(int x1, int x2, int y1, int y2)
     {
-        site->image_changed(x1, x2, y1, y2);
+        m_site->image_changed(x1, x2, y1, y2);
     }
     inline void progress_changed(float progress)
     {
-        float adjusted_progress = min_progress + progress * delta_progress;
-        site->progress_changed(adjusted_progress);
+        const float adjusted_progress = m_min_progress + progress * m_delta_progress;
+        m_site->progress_changed(adjusted_progress);
     }
     inline void stats_changed()
     {
-        stats.add(worker->get_stats());
-        site->stats_changed(stats);
+        m_stats.add(m_worker->get_stats());
+        m_site->stats_changed(m_stats);
     }
     inline void status_changed(int status_val)
     {
-        site->status_changed(status_val);
+        m_site->status_changed(status_val);
     }
     inline bool try_finished_cond()
     {
-        return site->is_interrupted();
+        return m_site->is_interrupted();
     }
     // used for calculating (x,y,z,w) pixel coords
     dvec4 deltax, deltay;         // step from 1 pixel to the next in x,y directions
@@ -103,26 +103,22 @@ private:
         SHOULD_RELAX = (SHOULD_SHALLOWEN | SHOULD_LOOSEN)
     };
 
-    // params from ctor
-    int debug_flags;
-    calc_options options;
-    d *params;
-    IImage *im;
-    IFractWorker *worker;
-    // for callbacks
-    IFractalSite *site;
+    int m_debug_flags;
+    calc_options m_options;
+    d *m_params;
+    IImage *m_im;
+    IFractWorker *m_worker;
+    IFractalSite *m_site;
     // last time we redrew the image to this line
-    int last_update_y;
-    float min_progress;
-    float delta_progress;
-    pixel_stat_t stats;
+    int m_last_update_y;
+    float m_min_progress;
+    float m_delta_progress;
+    pixel_stat_t m_stats;
 
     void draw(int rsize, int drawsize, float min_progress, float max_progress);
     void draw_aa(float min_progress, float max_progress);
     int updateiters();
     void set_progress_range(float min, float max);
-    // private drawing methods
-    void send_quit();
     // redraw the image to this line
     // also checks for interruptions & returns true if we should stop
     bool update_image(int i);

--- a/fract4d/c/model/fractfunc.h
+++ b/fract4d/c/model/fractfunc.h
@@ -48,9 +48,7 @@ public:
     // additional flags controlling debugging & profiling options
     void set_debug_flags(int debug_flags);
     void draw_all();
-    void draw(int rsize, int drawsize, float min_progress, float max_progress);
-    void draw_aa(float min_progress, float max_progress);
-    int updateiters();
+
     // a vector from the eye through the pixel at (x,y)
     dvec4 vec_for_point(double x, double y);
     // @TODO: review the need of having this coupling
@@ -87,7 +85,6 @@ public:
         return site->is_interrupted();
     }
     // used for calculating (x,y,z,w) pixel coords
-    dmat4 rot;                    // scaled rotation matrix
     dvec4 deltax, deltay;         // step from 1 pixel to the next in x,y directions
     dvec4 delta_aa_x, delta_aa_y; // offset between subpixels
     dvec4 topleft;                // top left corner of screen
@@ -95,10 +92,7 @@ public:
     dvec4 eye_point;              // where user's eye is (for 3d mode)
 
 private:
-    // MEMBER VARS
-    bool ok; // did this instance get constructed ok?
-    // (* this should really be done with exns but they are unreliable
-    //  * in the presence of pthreads - grrr *)
+
     // do every nth pixel twice as deep as the others to
     // see if we need to auto-deepen
     enum
@@ -116,6 +110,7 @@ private:
         SHOULD_IMPROVE = (SHOULD_DEEPEN | SHOULD_TIGHTEN),
         SHOULD_RELAX = (SHOULD_SHALLOWEN | SHOULD_LOOSEN)
     };
+
     // params from ctor
     int eaa;
     int maxiter;
@@ -137,6 +132,10 @@ private:
     float min_progress;
     float delta_progress;
     pixel_stat_t stats;
+
+    void draw(int rsize, int drawsize, float min_progress, float max_progress);
+    void draw_aa(float min_progress, float max_progress);
+    int updateiters();
     void set_progress_range(float min, float max);
     // private drawing methods
     void send_quit();

--- a/fract4d/c/model/fractfunc.h
+++ b/fract4d/c/model/fractfunc.h
@@ -36,15 +36,16 @@ public:
         IFractWorker *,
         IImage *,
         IFractalSite *);
-    ~fractFunc(){};
-    // additional flags controlling debugging & profiling options
-    void set_debug_flags(int);
-    void draw_all();
+    ~fractFunc() = default;
 
-    // a vector from the eye through the pixel at (x,y)
-    dvec4 vec_for_point(double x, double y);
     // @TODO: review the need of having this coupling
     friend class STFractWorker;
+
+    // additional flags controlling debugging & profiling options
+    void set_debug_flags(int);
+
+    void draw_all();
+
     // callback wrappers
     inline void iters_changed(int iters)
     {
@@ -76,6 +77,10 @@ public:
     {
         return m_site->is_interrupted();
     }
+
+    // a vector from the eye through the pixel at (x,y)
+    dvec4 vec_for_point(double x, double y);
+
     // used for calculating (x,y,z,w) pixel coords
     dvec4 deltax, deltay;         // step from 1 pixel to the next in x,y directions
     dvec4 delta_aa_x, delta_aa_y; // offset between subpixels
@@ -105,7 +110,6 @@ private:
 
     int m_debug_flags;
     calc_options m_options;
-    d *m_params;
     IImage *m_im;
     IFractWorker *m_worker;
     IFractalSite *m_site;
@@ -117,16 +121,20 @@ private:
 
     void draw(int rsize, int drawsize, float min_progress, float max_progress);
     void draw_aa(float min_progress, float max_progress);
-    int updateiters();
-    void set_progress_range(float min, float max);
+
     // redraw the image to this line
     // also checks for interruptions & returns true if we should stop
     bool update_image(int i);
+
     // prepare for deepening by clearing 'in'-fated pixels
     void clear_in_fates();
+
     // clear auto-deepen and last_update
     void reset_counts();
+    int updateiters();
+
     void reset_progress(float progress);
+    void set_progress_range(float min, float max);
 };
 
 #endif /* _FRACTFUNC_H_ */

--- a/fract4d/c/model/pointfunc.cpp
+++ b/fract4d/c/model/pointfunc.cpp
@@ -1,28 +1,6 @@
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-#include <unistd.h>
-#include <dlfcn.h>
-#include <cstdio>
-
 #include "pointfunc.h"
-#include "pf.h"
-#include "model/colormap.h"
-#include "model/color.h"
 
-
-pointFunc *pointFunc::create(
-    pf_obj *pfo,
-    ColorMap *cmap)
-{
-    if (NULL == pfo || NULL == cmap)
-    {
-        return NULL;
-    }
-    return new pf_wrapper(pfo, cmap);
-}
-
-void pf_wrapper::calc(
+void pointFunc::calc(
     // in params
     const double *params, int nIters,
     // periodicity
@@ -67,23 +45,4 @@ void pf_wrapper::calc(
     }
     *pFate = (fate_t)fate;
     *pIndex = (float)dist;
-}
-
-inline rgba_t pf_wrapper::recolor(double dist, fate_t fate, rgba_t current) const
-{
-    int solid = 0;
-    int inside = 0;
-    if (fate & FATE_DIRECT)
-    {
-        return current;
-    }
-    if (fate & FATE_SOLID)
-    {
-        solid = 1;
-    }
-    if (fate & FATE_INSIDE)
-    {
-        inside = 1;
-    }
-    return m_cmap->lookup_with_transfer(dist, solid, inside);
 }

--- a/fract4d/c/model/pointfunc.cpp
+++ b/fract4d/c/model/pointfunc.cpp
@@ -6,24 +6,20 @@
 #include <cstdio>
 
 #include "pointfunc.h"
-
 #include "pf.h"
-
 #include "model/colormap.h"
-#include "model/site.h"
 #include "model/color.h"
 
 
 pointFunc *pointFunc::create(
     pf_obj *pfo,
-    ColorMap *cmap,
-    IFractalSite *site)
+    ColorMap *cmap)
 {
     if (NULL == pfo || NULL == cmap)
     {
         return NULL;
     }
-    return new pf_wrapper(pfo, cmap, site);
+    return new pf_wrapper(pfo, cmap);
 }
 
 void pf_wrapper::calc(
@@ -71,12 +67,6 @@ void pf_wrapper::calc(
     }
     *pFate = (fate_t)fate;
     *pIndex = (float)dist;
-    int color_iters = (fate & FATE_INSIDE) ? -1 : *pnIters;
-    m_site->pixel_changed(
-        params, nIters, min_period_iters,
-        x, y, aa,
-        dist, fate, color_iters,
-        color->r, color->g, color->b, color->a);
 }
 
 inline rgba_t pf_wrapper::recolor(double dist, fate_t fate, rgba_t current) const

--- a/fract4d/c/model/pointfunc.cpp
+++ b/fract4d/c/model/pointfunc.cpp
@@ -13,12 +13,6 @@
 #include "model/site.h"
 #include "model/color.h"
 
-/* only here so it's visible to debugger */
-typedef struct
-{
-    pf_obj parent;
-    struct s_param p[PF_MAXPARAMS];
-} pf_real;
 
 pointFunc *pointFunc::create(
     pf_obj *pfo,

--- a/fract4d/c/model/pointfunc.h
+++ b/fract4d/c/model/pointfunc.h
@@ -1,7 +1,6 @@
 #ifndef __POINTFUNC_H_INCLUDED__
 #define __POINTFUNC_H_INCLUDED__
 
-class IFractalSite;
 class ColorMap;
 typedef struct s_pf_data pf_obj;
 typedef unsigned char fate_t;
@@ -14,8 +13,7 @@ public:
     /* factory method for making new pointFuncs */
     static pointFunc *create(
         pf_obj *pfo,
-        ColorMap *cmap,
-        IFractalSite *site);
+        ColorMap *cmap);
     virtual ~pointFunc(){}
     virtual void calc(
         // in params. params points to [x,y,cx,cy]
@@ -36,13 +34,11 @@ class pf_wrapper : public pointFunc
 private:
     pf_obj *m_pfo;
     ColorMap *m_cmap;
-    IFractalSite *m_site;
 
 public:
     pf_wrapper(
         pf_obj *pfo,
-        ColorMap *cmap,
-        IFractalSite *site) : m_pfo(pfo), m_cmap(cmap), m_site(site) {}
+        ColorMap *cmap) : m_pfo(pfo), m_cmap(cmap) {}
     /* we don't own the member pointers, so we don't delete them */
     ~pf_wrapper() {}
     void calc(

--- a/fract4d/c/model/pointfunc.h
+++ b/fract4d/c/model/pointfunc.h
@@ -1,46 +1,20 @@
 #ifndef __POINTFUNC_H_INCLUDED__
 #define __POINTFUNC_H_INCLUDED__
 
-class ColorMap;
-typedef struct s_pf_data pf_obj;
-typedef unsigned char fate_t;
-typedef struct s_rgba rgba_t;
+#include "pf.h"
+#include "model/color.h"
+#include "model/colormap.h"
 
 /* interface for function object which computes and/or colors a single point */
 class pointFunc
 {
-public:
-    /* factory method for making new pointFuncs */
-    static pointFunc *create(
-        pf_obj *pfo,
-        ColorMap *cmap);
-    virtual ~pointFunc(){}
-    virtual void calc(
-        // in params. params points to [x,y,cx,cy]
-        const double *params, int nIters,
-        // periodicity params
-        int min_period_iters, double period_tolerance,
-        // warping
-        int warp_param,
-        // only used for debugging
-        int x, int y, int aa,
-        // out params
-        rgba_t *color, int *pnIters, float *pIndex, fate_t *pFate) const = 0;
-    virtual rgba_t recolor(double dist, fate_t fate, rgba_t current) const = 0;
-};
-
-class pf_wrapper : public pointFunc
-{
-private:
     pf_obj *m_pfo;
     ColorMap *m_cmap;
-
 public:
-    pf_wrapper(
+    pointFunc(
         pf_obj *pfo,
         ColorMap *cmap) : m_pfo(pfo), m_cmap(cmap) {}
-    /* we don't own the member pointers, so we don't delete them */
-    ~pf_wrapper() {}
+
     void calc(
         // in params
         const double *params, int nIters,
@@ -52,7 +26,25 @@ public:
         int x, int y, int aa,
         // out params
         rgba_t *color, int *pnIters, float *pIndex, fate_t *pFate) const;
-    inline rgba_t recolor(double dist, fate_t fate, rgba_t current) const;
+
+    inline rgba_t recolor(double dist, fate_t fate, rgba_t current) const
+    {
+        int solid = 0;
+        int inside = 0;
+        if (fate & FATE_DIRECT)
+        {
+            return current;
+        }
+        if (fate & FATE_SOLID)
+        {
+            solid = 1;
+        }
+        if (fate & FATE_INSIDE)
+        {
+            inside = 1;
+        }
+        return m_cmap->lookup_with_transfer(dist, solid, inside);
+    }
 };
 
 #endif

--- a/fract4d/c/model/stats.cpp
+++ b/fract4d/c/model/stats.cpp
@@ -14,7 +14,7 @@ void s_pixel_stat::reset()
 
 void s_pixel_stat::add(const pixel_stat_t &other)
 {
-    for (int i = 0; i < NUM_STATS; ++i)
+    for (auto i = 0; i < NUM_STATS; ++i)
     {
         s[i] += other.s[i];
     }
@@ -22,20 +22,20 @@ void s_pixel_stat::add(const pixel_stat_t &other)
 
 double s_pixel_stat::worse_depth_ratio() const
 {
-    return ((double)s[WORSE_DEPTH_PIXELS]) / s[PIXELS];
+    return static_cast<double>(s[WORSE_DEPTH_PIXELS]) / s[PIXELS];
 }
 
 double s_pixel_stat::better_depth_ratio() const
 {
-    return ((double)s[BETTER_DEPTH_PIXELS]) / s[PIXELS];
+    return static_cast<double>(s[BETTER_DEPTH_PIXELS]) / s[PIXELS];
 }
 
 double s_pixel_stat::worse_tolerance_ratio() const
 {
-    return ((double)s[WORSE_TOLERANCE_PIXELS]) / s[PIXELS];
+    return static_cast<double>(s[WORSE_TOLERANCE_PIXELS]) / s[PIXELS];
 }
 
 double s_pixel_stat::better_tolerance_ratio() const
 {
-    return ((double)s[BETTER_TOLERANCE_PIXELS]) / s[PIXELS];
+    return static_cast<double>(s[BETTER_TOLERANCE_PIXELS]) / s[PIXELS];
 }

--- a/fract4d/c/model/worker.cpp
+++ b/fract4d/c/model/worker.cpp
@@ -16,10 +16,6 @@ IFractWorker *IFractWorker::create(
     }
     else
     {
-        STFractWorker *w = new STFractWorker();
-        if (!w)
-            return w;
-        w->init(pfo, cmap, im_, site);
-        return w;
+        return new STFractWorker(pfo, cmap, im_, site);
     }
 }

--- a/fract4d/c/model/worker.cpp
+++ b/fract4d/c/model/worker.cpp
@@ -7,12 +7,12 @@ void worker(job_info_t& tdata, STFractWorker *pFunc)
 }
 
 IFractWorker *IFractWorker::create(
-    int nThreads, pf_obj *pfo, ColorMap *cmap, IImage *im_, IFractalSite *site)
+    int numThreads, pf_obj *pfo, ColorMap *cmap, IImage *im_, IFractalSite *site)
 {
     // can IFDEF here if threads are not available
-    if (nThreads > 1)
+    if (numThreads > 1)
     {
-        return new MTFractWorker(nThreads, pfo, cmap, im_, site);
+        return new MTFractWorker(numThreads, pfo, cmap, im_, site);
     }
     else
     {

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -114,8 +114,7 @@ public:
     // sum squared differences between components of 2 colors
     int diff_colors(rgba_t a, rgba_t b);
     // make an int corresponding to an RGB triple
-    inline int RGB2INT(int x, int y);
-    inline int Pixel2INT(rgba_t pixel);
+    inline int Pixel2INT(int x, int y);
     // calculate a row of boxes
     void box_row(int w, int y, int rsize);
     // calculate a row of boxes, quickly

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -8,6 +8,7 @@
 #include "model/stats.h"
 #include "model/pointfunc.h"
 #include "model/threadpool.h"
+#include "model/calcoptions.h"
 
 class fractFunc;
 class ColorMap;
@@ -42,8 +43,8 @@ class IFractWorker
 {
 public:
     static IFractWorker *create(
-        int nThreads, pf_obj *pfo, ColorMap *cmap, IImage *im_, IFractalSite *site);
-    virtual void set_fractFunc(fractFunc *ff_) = 0;
+        int nThreads, pf_obj *, ColorMap *, IImage *, IFractalSite *);
+    virtual void set_fractFunc(fractFunc *) = 0;
     // calculate a row of antialiased pixels
     virtual void row_aa(int x, int y, int n) = 0;
     // calculate a row of pixels
@@ -148,6 +149,7 @@ private:
     // return true if this pixel needs recalc in AA pass
     bool needs_aa_calc(int x, int y);
 
+    calc_options *options;
     IFractalSite *site;
     fractFunc *ff;
     /* pointers to data also held in fractFunc */
@@ -165,11 +167,13 @@ private:
 class MTFractWorker final: public IFractWorker
 {
 public:
-    MTFractWorker(int n,
-                  pf_obj *obj,
-                  ColorMap *cmap,
-                  IImage *im,
-                  IFractalSite *site);
+    MTFractWorker(
+        int n,
+        pf_obj *,
+        ColorMap *,
+        IImage *,
+        IFractalSite *
+    );
     ~MTFractWorker(){};
     void set_fractFunc(fractFunc *ff);
     // operations

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -77,9 +77,6 @@ class STFractWorker final: public IFractWorker
 {
 public:
     STFractWorker(pf_obj *, ColorMap *, IImage *, IFractalSite *) noexcept;
-    // needed because having unique_ptr member deletes copy ctor
-    STFractWorker(STFractWorker&&) noexcept;
-    ~STFractWorker(){};
 
     void set_fractFunc(fractFunc *ff);
     // heuristic to see if we should use periodicity checking for next point
@@ -173,7 +170,6 @@ public:
         IImage *,
         IFractalSite *
     );
-    ~MTFractWorker(){};
     void set_fractFunc(fractFunc *ff);
     // operations
     void row_aa(int x, int y, int n);

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -69,7 +69,7 @@ public:
     virtual bool find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root) = 0;
     virtual void flush() = 0;
 
-    virtual ~IFractWorker(){};
+    virtual ~IFractWorker() = default;
 protected:
     mutable pixel_stat_t m_stats;
 };

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -100,7 +100,7 @@ public:
     void box(int x, int y, int rsize);
     // does the point at (x,y) have the same colour & iteration count
     // as the target?
-    inline bool isTheSame(bool bFlat, int targetIter, int targetCol, int x, int y);
+    inline bool isTheSame(int targetIter, int targetCol, int x, int y);
     // is the square with its top-left corner at (x,y) close-enough to flat
     // that we could interpolate & get a decent-looking image?
     bool isNearlyFlat(int x, int y, int rsize);

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -45,6 +45,8 @@ public:
     static IFractWorker *create(
         int numThreads, pf_obj *, ColorMap *, IImage *, IFractalSite *);
 
+    IFractWorker(): m_stats{} {}
+
     virtual void set_fractFunc(fractFunc *) = 0;
     // calculate a row of antialiased pixels
     virtual void row_aa(int x, int y, int n) = 0;
@@ -68,9 +70,7 @@ public:
     virtual void flush() = 0;
 
     virtual ~IFractWorker(){};
-    bool ok() const { return m_ok; }
 protected:
-    bool m_ok = true;
     mutable pixel_stat_t m_stats;
 };
 

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -43,7 +43,7 @@ class IFractWorker
 {
 public:
     static IFractWorker *create(
-        int nThreads, pf_obj *, ColorMap *, IImage *, IFractalSite *);
+        int numThreads, pf_obj *, ColorMap *, IImage *, IFractalSite *);
     virtual void set_fractFunc(fractFunc *) = 0;
     // calculate a row of antialiased pixels
     virtual void row_aa(int x, int y, int n) = 0;
@@ -69,7 +69,7 @@ public:
     bool ok() const { return m_ok; }
 protected:
     bool m_ok = true;
-    mutable pixel_stat_t stats;
+    mutable pixel_stat_t m_stats;
 };
 
 /* per-worker-thread fractal info */
@@ -148,17 +148,17 @@ private:
     // return true if this pixel needs recalc in AA pass
     bool needs_aa_calc(int x, int y);
 
-    calc_options *options;
-    IFractalSite *site;
-    fractFunc *ff;
+    calc_options *m_options;
+    IFractalSite *m_site;
+    fractFunc *m_ff;
     /* pointers to data also held in fractFunc */
-    IImage *im;
+    IImage *m_im;
     // function object which calculates the colors of points
     // this is per-thread-func so it doesn't have to be re-entrant
     // and can have member vars
-    std::unique_ptr<pointFunc> pf;
+    std::unique_ptr<pointFunc> m_pf;
     // period guessing
-    int lastIter; // how many iterations did last pixel take?
+    int m_lastPointIters; // how many iterations did last pixel take?
 };
 
 // a composite subclass which holds an array of STFractWorkers and
@@ -167,7 +167,7 @@ class MTFractWorker final: public IFractWorker
 {
 public:
     MTFractWorker(
-        int n,
+        int numThreads,
         pf_obj *,
         ColorMap *,
         IImage *,
@@ -199,9 +199,8 @@ private:
     void send_box_row(int w, int y, int rsize);
     void send_qbox_row(int w, int y, int rsize, int drawsize);
 
-    int nWorkers;
-    std::vector<STFractWorker> ptf;
-    std::unique_ptr<tpool<job_info_t, STFractWorker>> ptp;
+    std::vector<STFractWorker> m_workers;
+    std::unique_ptr<tpool<job_info_t, STFractWorker>> m_threads;
 };
 
 #endif

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -192,8 +192,7 @@ public:
     bool find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root);
 private:
     /* wait for a ready thread then give it some work */
-    void send_cmd(job_type_t job, int x, int y, int param);
-    void send_cmd(job_type_t job, int x, int y, int param, int param2);
+    void send_cmd(job_type_t job, int x, int y, int param, int param2 = 0);
     void send_quit();
     void send_box(int x, int y, int rsize);
     void send_row(int x, int y, int n);

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -148,6 +148,7 @@ private:
     // return true if this pixel needs recalc in AA pass
     bool needs_aa_calc(int x, int y);
 
+    IFractalSite *site;
     fractFunc *ff;
     /* pointers to data also held in fractFunc */
     IImage *im;

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -102,8 +102,6 @@ private:
     void compute_stats(const dvec4 &pos, int iter, fate_t, int x, int y);
     void compute_auto_deepen_stats(const dvec4 &pos, int iter, int x, int y);
     void compute_auto_tolerance_stats(const dvec4 &pos, int iter, int x, int y);
-    // return true if this pixel needs recalc in AA pass
-    bool needs_aa_calc(int x, int y);
     // does the point at (x,y) have the same colour & iteration count as the target?
     bool isTheSame(int targetIter, int targetCol, int x, int y);
     // calculate this point using antialiasing
@@ -116,9 +114,9 @@ private:
     // (as for antialias pass)
     int periodGuess(int last);
     // update whether last pixel bailed
-    void periodSet(int *ppos);
+    void periodSet(int ppos);
     // draw a rectangle of this colour
-    void rectangle(rgba_t, int x, int y, int w, int h, bool force = false);
+    void rectangle(rgba_t, int x, int y, int w, int h);
     void rectangle_with_iter(rgba_t, fate_t, int iter, float index, int x, int y, int w, int h);
 
     // EXPERIMENTAL (not in use)
@@ -133,10 +131,6 @@ private:
     void interpolate_row(int x, int y, int rsize);
     // compare a prediction against the real answer & update stats
     void check_guess(int x, int y, rgba_t pixel, fate_t fate, int iter, float index);
-    // periodicity guesser to look up nearby points & guess based on that
-    int periodGuess(int x, int y);
-    // calculate a column of pixels
-    void col(int x, int y, int n);
     // sum squared differences between components of 2 colors
     int diff_colors(rgba_t a, rgba_t b);
 

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -76,7 +76,8 @@ protected:
 class STFractWorker final: public IFractWorker
 {
 public:
-    STFractWorker(pf_obj *, ColorMap *, IImage *, IFractalSite *) noexcept;
+    STFractWorker(pf_obj *pfo, ColorMap *cmap, IImage *im, IFractalSite *site) noexcept:
+        m_site{site}, m_im{im}, m_pf{pfo, cmap}, m_lastPointIters{0} { }
 
     void set_fractFunc(fractFunc *ff);
     // heuristic to see if we should use periodicity checking for next point
@@ -153,7 +154,7 @@ private:
     // function object which calculates the colors of points
     // this is per-thread-func so it doesn't have to be re-entrant
     // and can have member vars
-    std::unique_ptr<pointFunc> m_pf;
+    pointFunc m_pf;
     // period guessing
     int m_lastPointIters; // how many iterations did last pixel take?
 };

--- a/fract4d/fractal.py
+++ b/fract4d/fractal.py
@@ -758,6 +758,7 @@ class T(fctutils.T):
     def image_changed(self, x1, y1, x2, y2):
         pass
 
+    # you need to rename this to pixel_changed to get pixel debug info
     def _pixel_changed(self, params, x, y, aa, maxIters,
                        nNoPeriodIters, dist, fate, nIters, r, g, b, a):
         # remove underscore to debug fractal generation

--- a/fract4d/tests/test_fractal.py
+++ b/fract4d/tests/test_fractal.py
@@ -1307,7 +1307,6 @@ The image may not display correctly. Please upgrade to version 99.9 or higher.''
 
     def testDiagonalWithColorFuncs(self):
         f = fractal.T(Test.g_comp)
-        #f.pixel_changed = f._pixel_changed
         f.set_formula("test.frm", "test_simpleshape")
         f.set_inner("test.cfrm", "flat")
         f.set_outer("test.cfrm", "flat")


### PR DESCRIPTION
No (intended) behavior change in this PR, perhaps some minor improvements (loops, temp vars, repeated/unneeded operations).
- New entity "calcoptions" to avoid carrying all its properties as constructor parameters for underneath classes.
- Introduced the use of unique_ptr as well as reviewed some class initializations to simplify.
- remove some unused/unreachable code.
- rename and reorganize members for some classes to clarify public interfaces and the use of private members.
- introduced some std utilities like vector.
- started working towards SOLID principles (specially "single responsibility")
- update old fashion idioms like c-style type casting 
- ...

\* for this PR I want to keep the current fract4dc interface. This impedes some decoupling (at least without introducing more complexity on the python extension implementation). For example: STFractWorker is a friend class of fractFunc. That's an already identified code smell, and you can can see how python tests using fw_create need to, without apparent reason, to create a fractFunc when they only want to test the worker.