### PR TITLE
Fix relative manual installation directory

### DIFF
--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -1274,7 +1274,7 @@ class MainWindow:
 
         # look locally first to support run-before-install
         local_dir = "manual/public/"
-        install_dir = "../../share/gnome/help/gnofract4d/C/"
+        install_dir = "../../../../../share/gnome/help/gnofract4d/C/"
 
         helpfile = fractconfig.T.find_resource(
             base_help_file, local_dir, install_dir)


### PR DESCRIPTION
Installed into the system in e.g.:

/usr/lib/python3.8/site-packages/fract4dgui/

----

I thought this was working - not sure what changed here. Is this OK for everyone?

(manual looks very modern now! Definitely the right decision to bundle the HTML, I did install Hugo to try it myself but a lot of Go modules which would not make a great dependency for Gnofract 4d installation on Gentoo).
