### PR TITLE
Install manual in share/gnofract4d/help

### DIFF
--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -1274,7 +1274,7 @@ class MainWindow:
 
         # look locally first to support run-before-install
         local_dir = "manual/public/"
-        install_dir = "../../share/gnome/help/gnofract4d/C/"
+        install_dir = "../../share/gnofract4d/help/"
 
         helpfile = fractconfig.T.find_resource(
             base_help_file, local_dir, install_dir)

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ and includes a Fractint-compatible parser for your own fractal formulas.''',
         ),
         # documentation
         (
-            'share/gnome/help/gnofract4d/C',
+            'share/gnofract4d/help',
             get_files("manual/public", "html") +
             get_files("manual/public", "png") +
             get_files("manual/public", "css")


### PR DESCRIPTION
Using a web browser to view now, not Yelp. Make the path consistent with
other Gnofract 4D data to allow simplification.

--- 

This doesn't fix the problem (could temporarily add the dots for Linux?) but it is an enabling step to improving the code that finds data.