### PR TITLE
remove fract4d_stdlib

### DIFF
--- a/fract4d/__init__.py
+++ b/fract4d/__init__.py
@@ -1,3 +1,8 @@
 #!/usr/bin/env python3
 
 # package file for fract4d
+
+import sys
+import os
+
+sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_NOW)

--- a/setup.py
+++ b/setup.py
@@ -127,21 +127,7 @@ module_fract4dc = Extension(
     define_macros=define_macros
 )
 
-module_cmap = Extension(
-    'fract4d.fract4d_stdlib',
-    sources=[
-        'fract4d/c/model/colorutils.cpp',
-        'fract4d/c/model/colormap.cpp',
-        'fract4d/c/model/image.cpp',
-
-        'fract4d/c/fract_stdlib.cpp'
-    ],
-    include_dirs=['fract4d/c', 'fract4d/c/model'],
-    libraries=libraries,
-    define_macros=[('_REENTRANT', 1)]
-)
-
-modules = [module_fract4dc, module_cmap]
+modules = [module_fract4dc]
 
 def get_files(dir, ext):
     return [os.path.join(dir, x) for x in os.listdir(dir) if x.endswith(ext)]
@@ -154,13 +140,6 @@ def get_icons():
     return icons
 
 so_extension = sysconfig.get_config_var("EXT_SUFFIX")
-
-with open("fract4d/c/cmap_name.h", "w") as fh:
-    fh.write("""
-#ifndef CMAP_NAME
-#define CMAP_NAME "/fract4d_stdlib%s"
-#endif
-""" % so_extension)
 
 setup(
     name='gnofract4d',
@@ -237,7 +216,6 @@ and includes a Fractint-compatible parser for your own fractal formulas.''',
 
 lib_targets = {
     "fract4dc" + so_extension: "fract4d",
-    "fract4d_stdlib" + so_extension: "fract4d",
 }
 
 


### PR DESCRIPTION
Complicated story: at runtime, we load a generated shared
object containing the code for the fractal. We want that to
be able to call some helper functions that are contained in
the fract4dc module. That module is also dynamically loaded,
and by default Python loads it without specifying RTLD_GLOBAL.
That means functions in it are not visible to other dynamically
loaded modules, which we need.

Originally I resolved this with a terrible hack: create another .so
containing the code I wanted, and dlopen() that specifically
with RTLD_GLOBAL. Looks like there is an easier fix, using
sys.setdlopenflags, which I never realized. Thanks @mindhells !

This simplifies things by removing that extra complication. Sweet.
