### PR TITLE
Decouple fractFunc and STFractWorker

### DIFF
--- a/examples/cpp/custom_formula.cpp
+++ b/examples/cpp/custom_formula.cpp
@@ -17,6 +17,7 @@
 
 #include "model/fractfunc.h"
 #include "model/vectors.h"
+#include "model/fractgeometry.h"
 
 #define MAX_ITERATIONS 100
 
@@ -85,22 +86,11 @@ int main() {
     auto im{std::make_unique<image>()};
     im->set_resolution(640, 480, -1, -1);
 
-    // calculate the 4D vectors: topleft and deltas (x, y)
-    dvec4 center = dvec4(
-        pos_params[XCENTER], pos_params[YCENTER],
-        pos_params[ZCENTER], pos_params[WCENTER]
-    );
-    dmat4 rot_matrix = rotated_matrix(const_cast<double *>(pos_params));
-    rot_matrix = rot_matrix / im->totalXres();
-    dvec4 deltax = rot_matrix[VX];
-    dvec4 deltay = rot_matrix[VY];
-    dvec4 delta_aa_x = deltax / 2.0;
-    dvec4 delta_aa_y = deltay / 2.0;
-    dvec4 topleft = center - deltax * im->totalXres() / 2.0 - deltay * im->totalYres() / 2.0;
-    topleft += delta_aa_x + delta_aa_y;
-
     const auto w = im->Xres();
     const auto h = im->Yres();
+    // calculate the 4D vectors: topleft and deltas (x, y)
+    fract_geometry geometry { const_cast<double *>(pos_params), false, w, h, 0, 0 };
+
     // we put these variables out of the loop scope to use its previous value
     int iters_taken = 0;
     int min_period_iters = 0;
@@ -108,7 +98,7 @@ int main() {
     for (auto x = 0; x < w; x++) {
         for (auto y = 0; y < h; y++) {
             // calculate the position in 4D (x, y, z, w)
-            dvec4 pos = topleft + x * deltax + y * deltay;
+            dvec4 pos = geometry.vec_for_point_2d(x, y);
             // run the formula
             double dist = 0.0;
             int fate = 0;

--- a/fract4d/c/fract4dc/functions.cpp
+++ b/fract4d/c/fract4dc/functions.cpp
@@ -113,13 +113,13 @@ namespace functions {
         switch (vec_type)
         {
         case DELTA_X:
-            vec = ff->deltax;
+            vec = ff->get_geometry().deltax;
             break;
         case DELTA_Y:
-            vec = ff->deltay;
+            vec = ff->get_geometry().deltay;
             break;
         case TOPLEFT:
-            vec = ff->topleft;
+            vec = ff->get_geometry().topleft;
             break;
         default:
             PyErr_SetString(PyExc_ValueError, "Unknown vector requested");
@@ -157,7 +157,7 @@ namespace functions {
             return NULL;
         }
 
-        dvec4 lookvec = ff->vec_for_point(x, y);
+        dvec4 lookvec = ff->get_geometry().vec_for_point_3d(x, y);
 
         return Py_BuildValue(
             "(dddd)",

--- a/fract4d/c/fract4dc/utils.cpp
+++ b/fract4d/c/fract4dc/utils.cpp
@@ -6,6 +6,7 @@
 #include "model/fractfunc.h"
 #include "model/colorutils.h"
 #include "model/vectors.h"
+#include "model/fractgeometry.h"
 
 #include "fract_stdlib.h"
 #include "pf.h"
@@ -26,7 +27,7 @@ namespace utils {
             return NULL;
         }
 
-        dmat4 rot = rotated_matrix(params);
+        dmat4 rot = fract_geometry::rotated_matrix(params);
 
         return Py_BuildValue(
             "((dddd)(dddd)(dddd)(dddd))",
@@ -51,7 +52,7 @@ namespace utils {
             return NULL;
         }
 
-        dvec4 eyevec = test_eye_vector(params, dist);
+        dvec4 eyevec = fract_geometry::eye_vector(params, dist);
 
         return Py_BuildValue(
             "(dddd)",

--- a/fract4d/c/model/MTFractWorker.cpp
+++ b/fract4d/c/model/MTFractWorker.cpp
@@ -28,11 +28,11 @@ MTFractWorker::MTFractWorker(
     }
 }
 
-void MTFractWorker::set_fractFunc(fractFunc *ff_)
+void MTFractWorker::set_context(IWorkerContext *context)
 {
     for (auto& worker: m_workers)
     {
-        worker.set_fractFunc(ff_);
+        worker.set_context(context);
     }
 }
 

--- a/fract4d/c/model/fractgeometry.h
+++ b/fract4d/c/model/fractgeometry.h
@@ -4,6 +4,12 @@
 #include "model/vectors.h"
 #include "model/enums.h"
 
+/*
+    this class performs the geometry calculations to give each point
+    within a 2d slice or 3d projection its corresponding 4-dimensional
+    space value in the form of a 4d vector
+*/
+
 class fract_geometry final
 {
 public:

--- a/fract4d/c/model/fractgeometry.h
+++ b/fract4d/c/model/fractgeometry.h
@@ -1,0 +1,91 @@
+#ifndef __FRACTGEOMETRY_H_INCLUDED__
+#define __FRACTGEOMETRY_H_INCLUDED__
+
+#include "model/vectors.h"
+#include "model/enums.h"
+
+class fract_geometry final
+{
+public:
+    // used for calculating (x,y,z,w) pixel coords
+    dvec4 deltax, deltay;         // step from 1 pixel to the next in x,y directions
+    dvec4 delta_aa_x, delta_aa_y; // offset between subpixels
+    dvec4 topleft;                // top left corner of screen
+    dvec4 aa_topleft;             // topleft - offset to 1st subpixel to draw
+    dvec4 eye_point;              // where user's eye is (for 3d mode)
+
+    fract_geometry(
+        double *location, // x, y, z, w, magnitude, xy, xz, xw, yz, yw, zw
+        bool y_flip,
+        int width,
+        int height,
+        int x_offset,
+        int y_offset) noexcept
+    {
+        const dvec4 center = dvec4(
+            location[XCENTER], location[YCENTER],
+            location[ZCENTER], location[WCENTER]
+        );
+        dmat4 rot = rotated_matrix(location);
+        eye_point = center + rot[VZ] * -10.0; // FIXME add eye distance parameter
+        rot = rot / width;
+        // distance to jump for one pixel down or across
+        deltax = rot[VX];
+        // if yflip, draw Y axis down, otherwise up
+        deltay = y_flip ? rot[VY] : -rot[VY];
+        // half that distance
+        delta_aa_x = deltax / 2.0;
+        delta_aa_y = deltay / 2.0;
+        // topleft is now top left corner of top left pixel...
+        topleft = center -
+                deltax * width / 2.0 -
+                deltay * height / 2.0;
+        // offset to account for tiling, if any
+        topleft += x_offset * deltax;
+        topleft += y_offset * deltay;
+        // .. then offset to center of pixel
+        topleft += delta_aa_x + delta_aa_y;
+        // antialias: offset to middle of top left quadrant of pixel
+        aa_topleft = topleft - (delta_aa_y + delta_aa_x) / 2.0;
+    }
+
+    inline dvec4 vec_for_point_2d(double x, double y) const
+    {
+        return topleft + x * deltax + y * deltay;
+    }
+
+    inline dvec4 vec_for_point_2d_aa(double x, double y) const
+    {
+        return aa_topleft + x * deltax + y * deltay;
+    }
+
+    // a vector from the eye through the pixel at (x,y)
+    inline dvec4 vec_for_point_3d(double x, double y) const
+    {
+        dvec4 vec = vec_for_point_2d(x, y) - eye_point;
+        vec.norm();
+        return vec;
+    }
+
+    // The eye vector is the line between the center of the screen and the
+    // point where the user's eye is deemed to be. It's effectively the line
+    // perpendicular to the screen in the -Z direction, scaled by the "eye distance"
+    static dvec4 eye_vector(double *location, double dist)
+    {
+        return rotated_matrix(location)[VZ] * -dist;
+    }
+
+    // produces the scaled rotation matrix from the location params
+    static dmat4 rotated_matrix(double *location)
+    {
+        return identity3D<double>(location[MAGNITUDE]) *
+            rotXY<double>(location[XYANGLE]) *
+            rotXZ<double>(location[XZANGLE]) *
+            rotXW<double>(location[XWANGLE]) *
+            rotYZ<double>(location[YZANGLE]) *
+            rotYW<double>(location[YWANGLE]) *
+            rotZW<double>(location[ZWANGLE]);
+    }
+};
+
+#endif


### PR DESCRIPTION
The idea is to remove the coupling between those 2 and it looks like the reason for the coupling to exist in the 1st place is `fractFunc` holding too many responsibilities.
One of those responsibilities is managing the geometry of the fractal, that's been moved to an specific class `fract_geometry`.
That geometry information is now pulled by `STFractWorker` from a new interface `IWorkerContext` so there's no need for it to be a friend of fractFunc anymore or even know about it.

In order for that to work, fractFunc must inherit from IWorkerContext. This means a little extra cost comes with the virtual functions. I've been thinking about using [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) or even different patterns like "dependency injection" to solve this, but I think that complicates the thing too much for the benefit you get from them.

As a final note/thought: I think there's more work to do in this direction and I'd have liked to bring a more complete solution but I'm rather busy at the moment. I hope this helps others to understand how everything works in the same way it helped me while doing it.