### PR TITLE
Fract4dc cleanup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,9 +10,11 @@ RUN \
     apt-get -y install libpng-dev libjpeg-dev python3-dev gtk3.0 libcairo2-dev python3-cairo python3-gi-cairo pkg-config python3-pip xvfb
 
 # bin/run_builds.sh deps
-RUN apt-get -y install software-properties-common && \
+RUN \
+    apt-get update && \
+    apt-get -y install software-properties-common && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get -y install python3.5 python3.5-dev python3.6 python3.6-dev python3.7 python3.7-dev python3.8 python3.8-dev
+    apt-get -y install python3.6 python3.6-dev python3.7 python3.7-dev python3.8 python3.8-dev
 
 # bin/run_pylint.sh deps
 RUN pip3 install pylint

--- a/docker/bin/run_builds.sh
+++ b/docker/bin/run_builds.sh
@@ -2,8 +2,7 @@
 
 docker-compose up -d --build
 docker-compose exec server bash -c "rm -rf build"
-docker-compose exec server bash -c "python3.5 ./setup.py build && \
-                                    python3.6 ./setup.py build && \
+docker-compose exec server bash -c "python3.6 ./setup.py build && \
                                     python3.7 ./setup.py build && \
                                     python3.8 ./setup.py build"
 docker-compose down

--- a/docker/bin/run_tox.sh
+++ b/docker/bin/run_tox.sh
@@ -2,8 +2,7 @@
 
 docker-compose up -d --build
 docker-compose exec server bash -c "rm -rf build"
-docker-compose exec server bash -c "python3.5 ./setup.py build && \
-                                    python3.6 ./setup.py build && \
+docker-compose exec server bash -c "python3.6 ./setup.py build && \
                                     python3.7 ./setup.py build && \
                                     python3.8 ./setup.py build && \
                                     tox"

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(example ${CMAKE_THREAD_LIBS_INIT})
 
 target_link_libraries(example ${CMAKE_DL_LIBS})
 
-add_definitions(-DTHREADS -D_REENTRANT -DPNG_ENABLED -DJPG_ENABLED)
+add_definitions(-DTHREADS -DPNG_ENABLED -DJPG_ENABLED)
 
 find_package(benchmark REQUIRED)
 target_link_libraries(example benchmark::benchmark)

--- a/fract4d/c/fract4dc/arenas.cpp
+++ b/fract4d/c/fract4dc/arenas.cpp
@@ -7,7 +7,7 @@
 
 namespace arenas {
 
-    PyObject * pyarena_create(PyObject *self, PyObject *args)
+    PyObject * pyarena_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         int page_size, max_pages;
         if (!PyArg_ParseTuple(
@@ -31,7 +31,7 @@ namespace arenas {
         return pyarena;
     }
 
-    PyObject * pyarena_alloc(PyObject *self, PyObject *args)
+    PyObject * pyarena_alloc([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyArena;
         int element_size;
@@ -79,7 +79,7 @@ arena_t arena_fromcapsule(PyObject *p)
     arena_t arena = (arena_t)PyCapsule_GetPointer(p, OBTYPE_ARENA);
     if (NULL == arena)
     {
-        fprintf(stderr, "%p : AR : BAD\n", p);
+        fprintf(stderr, "%p : AR : BAD\n", reinterpret_cast<void *>(p));
     }
 
     return arena;

--- a/fract4d/c/fract4dc/arenas.cpp
+++ b/fract4d/c/fract4dc/arenas.cpp
@@ -79,7 +79,7 @@ arena_t arena_fromcapsule(PyObject *p)
     arena_t arena = (arena_t)PyCapsule_GetPointer(p, OBTYPE_ARENA);
     if (NULL == arena)
     {
-        fprintf(stderr, "%p : AR : BAD\n", reinterpret_cast<void *>(p));
+        fprintf(stderr, "%p : AR : BAD\n", static_cast<void *>(p));
     }
 
     return arena;

--- a/fract4d/c/fract4dc/calcs.cpp
+++ b/fract4d/c/fract4dc/calcs.cpp
@@ -15,7 +15,7 @@
 
 namespace calcs {
 
-    PyObject * pystop_calc(PyObject *self, PyObject *args)
+    PyObject * pystop_calc([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pysite;
         if (!PyArg_ParseTuple(args, "O", &pysite))
@@ -35,7 +35,7 @@ namespace calcs {
         return Py_None;
     }
 
-    PyObject * pycalc(PyObject *self, PyObject *args, PyObject *kwds)
+    PyObject * pycalc([[maybe_unused]] PyObject *self, PyObject *args, PyObject *kwds)
     {
         calc_args *cargs = parse_calc_args(args, kwds);
         if (NULL == cargs)

--- a/fract4d/c/fract4dc/colormaps.cpp
+++ b/fract4d/c/fract4dc/colormaps.cpp
@@ -271,7 +271,7 @@ namespace colormaps {
         ColorMap *cmap = (ColorMap *)PyCapsule_GetPointer(capsule, OBTYPE_CMAP);
         if (NULL == cmap)
         {
-            fprintf(stderr, "%p : CM : BAD", reinterpret_cast<void *>(capsule));
+            fprintf(stderr, "%p : CM : BAD", static_cast<void *>(capsule));
         }
         return cmap;
     }

--- a/fract4d/c/fract4dc/colormaps.cpp
+++ b/fract4d/c/fract4dc/colormaps.cpp
@@ -9,7 +9,7 @@
 
 namespace colormaps {
 
-    PyObject * cmap_create(PyObject *self, PyObject *args)
+    PyObject * cmap_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         /* args = an array of (index,r,g,b,a) tuples */
         PyObject *pyarray, *pyret;
@@ -70,7 +70,7 @@ namespace colormaps {
         return pyret;
     }
 
-    PyObject * cmap_create_gradient(PyObject *self, PyObject *args)
+    PyObject * cmap_create_gradient([[maybe_unused]] PyObject *self, PyObject *args)
     {
         /* args = a gradient object:
         an array of objects with:
@@ -103,7 +103,7 @@ namespace colormaps {
     }
 
 
-    PyObject * pycmap_set_solid(PyObject *self, PyObject *args)
+    PyObject * pycmap_set_solid([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pycmap;
         int which, r, g, b, a;
@@ -127,7 +127,7 @@ namespace colormaps {
     }
 
 
-    PyObject * pycmap_set_transfer(PyObject *self, PyObject *args)
+    PyObject * pycmap_set_transfer([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pycmap;
         int which;
@@ -152,7 +152,7 @@ namespace colormaps {
     }
 
 
-    PyObject * cmap_pylookup(PyObject *self, PyObject *args)
+    PyObject * cmap_pylookup([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyobj, *pyret;
         double d;
@@ -178,7 +178,7 @@ namespace colormaps {
     }
 
 
-    PyObject * cmap_pylookup_with_flags(PyObject *self, PyObject *args)
+    PyObject * cmap_pylookup_with_flags([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyobj, *pyret;
         double d;
@@ -271,7 +271,7 @@ namespace colormaps {
         ColorMap *cmap = (ColorMap *)PyCapsule_GetPointer(capsule, OBTYPE_CMAP);
         if (NULL == cmap)
         {
-            fprintf(stderr, "%p : CM : BAD", capsule);
+            fprintf(stderr, "%p : CM : BAD", reinterpret_cast<void *>(capsule));
         }
         return cmap;
     }

--- a/fract4d/c/fract4dc/controllers.cpp
+++ b/fract4d/c/fract4dc/controllers.cpp
@@ -107,7 +107,7 @@ void fractal_controller::stop_calculating() {
 
 namespace controllers
 {
-    bool create_controller(PyObject *self, PyObject *args, FractalController *fc)
+    bool create_controller([[maybe_unused]] PyObject *self, PyObject *args, FractalController *fc)
     {
         char *library_file_path;
         PyObject *py_formula_params, *py_location_params;

--- a/fract4d/c/fract4dc/functions.cpp
+++ b/fract4d/c/fract4dc/functions.cpp
@@ -183,7 +183,7 @@ ffHandle * ff_fromcapsule(PyObject *pyff)
     ffHandle *ff = (ffHandle *)PyCapsule_GetPointer(pyff, OBTYPE_FFH);
     if (NULL == ff)
     {
-        fprintf(stderr, "%p : FF : CTOR\n", static_cast<void *>(ff));
+        fprintf(stderr, "%p : FF : BAD\n", static_cast<void *>(ff));
     }
     return ff;
 }

--- a/fract4d/c/fract4dc/functions.cpp
+++ b/fract4d/c/fract4dc/functions.cpp
@@ -183,7 +183,7 @@ ffHandle * ff_fromcapsule(PyObject *pyff)
     ffHandle *ff = (ffHandle *)PyCapsule_GetPointer(pyff, OBTYPE_FFH);
     if (NULL == ff)
     {
-        fprintf(stderr, "%p : FF : CTOR\n", reinterpret_cast<void *>(ff));
+        fprintf(stderr, "%p : FF : CTOR\n", static_cast<void *>(ff));
     }
     return ff;
 }

--- a/fract4d/c/fract4dc/functions.cpp
+++ b/fract4d/c/fract4dc/functions.cpp
@@ -16,7 +16,7 @@
 
 namespace functions {
 
-    PyObject * ff_create(PyObject *self, PyObject *args)
+    PyObject * ff_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pypfo, *pycmap, *pyim, *pysite, *pyworker;
         double params[N_PARAMS];
@@ -84,7 +84,7 @@ namespace functions {
         return pyret;
     }
 
-    PyObject * ff_get_vector(PyObject *self, PyObject *args)
+    PyObject * ff_get_vector([[maybe_unused]] PyObject *self, PyObject *args)
     {
         int vec_type;
         PyObject *pyFF;
@@ -133,7 +133,7 @@ namespace functions {
         return NULL;
     }
 
-    PyObject * ff_look_vector(PyObject *self, PyObject *args)
+    PyObject * ff_look_vector([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyFF;
         double x, y;
@@ -183,7 +183,7 @@ ffHandle * ff_fromcapsule(PyObject *pyff)
     ffHandle *ff = (ffHandle *)PyCapsule_GetPointer(pyff, OBTYPE_FFH);
     if (NULL == ff)
     {
-        fprintf(stderr, "%p : FF : CTOR\n", ff);
+        fprintf(stderr, "%p : FF : CTOR\n", reinterpret_cast<void *>(ff));
     }
     return ff;
 }

--- a/fract4d/c/fract4dc/images.cpp
+++ b/fract4d/c/fract4dc/images.cpp
@@ -46,7 +46,7 @@ namespace images {
         IImage *image = (IImage *)PyCapsule_GetPointer(pyimage, OBTYPE_IMAGE);
         if (NULL == image)
         {
-            fprintf(stderr, "%p : IM : BAD\n", reinterpret_cast<void *>(pyimage));
+            fprintf(stderr, "%p : IM : BAD\n", static_cast<void *>(pyimage));
         }
         return image;
     }
@@ -479,7 +479,7 @@ ImageWriter * image_writer_fromcapsule(PyObject *p)
     ImageWriter *iw = (ImageWriter *)PyCapsule_GetPointer(p, OBTYPE_IMAGE_WRITER);
     if (NULL == iw)
     {
-        fprintf(stderr, "%p : IW : BAD\n", reinterpret_cast<void *>(p));
+        fprintf(stderr, "%p : IW : BAD\n", static_cast<void *>(p));
     }
 
     return iw;

--- a/fract4d/c/fract4dc/images.cpp
+++ b/fract4d/c/fract4dc/images.cpp
@@ -12,7 +12,7 @@
 
 namespace images {
 
-    PyObject * image_create(PyObject *self, PyObject *args)
+    PyObject * image_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         int x, y;
         int totalx = -1, totaly = -1;
@@ -46,13 +46,13 @@ namespace images {
         IImage *image = (IImage *)PyCapsule_GetPointer(pyimage, OBTYPE_IMAGE);
         if (NULL == image)
         {
-            fprintf(stderr, "%p : IM : BAD\n", pyimage);
+            fprintf(stderr, "%p : IM : BAD\n", reinterpret_cast<void *>(pyimage));
         }
         return image;
     }
 
 
-    PyObject * pyimage_lookup(PyObject *self, PyObject *args)
+    PyObject * pyimage_lookup([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyimage = NULL;
         double x, y;
@@ -76,7 +76,7 @@ namespace images {
     }
 
 
-    PyObject * image_resize(PyObject *self, PyObject *args)
+    PyObject * image_resize([[maybe_unused]] PyObject *self, PyObject *args)
     {
         int x, y;
         int totalx = -1, totaly = -1;
@@ -105,7 +105,7 @@ namespace images {
         return Py_None;
     }
 
-    PyObject * image_dims(PyObject *self, PyObject *args)
+    PyObject * image_dims([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyim;
 
@@ -134,7 +134,7 @@ namespace images {
         return pyret;
     }
 
-    PyObject * image_set_offset(PyObject *self, PyObject *args)
+    PyObject * image_set_offset([[maybe_unused]] PyObject *self, PyObject *args)
     {
         int x, y;
         PyObject *pyim;
@@ -161,7 +161,7 @@ namespace images {
         return Py_None;
     }
 
-    PyObject * image_clear(PyObject *self, PyObject *args)
+    PyObject * image_clear([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyim;
 
@@ -182,7 +182,7 @@ namespace images {
         return Py_None;
     }
 
-    PyObject * image_writer_create(PyObject *self, PyObject *args)
+    PyObject * image_writer_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyim;
         char *filename;
@@ -212,7 +212,7 @@ namespace images {
         return PyCapsule_New(writer, OBTYPE_IMAGE_WRITER, pyimage_writer_delete);
     }
 
-    PyObject * image_read(PyObject *self, PyObject *args)
+    PyObject * image_read([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyim;
         char *filename;
@@ -246,7 +246,7 @@ namespace images {
         return Py_None;
     }
 
-    PyObject * image_save_header(PyObject *self, PyObject *args)
+    PyObject * image_save_header([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyimwriter;
         if (!PyArg_ParseTuple(args, "O", &pyimwriter))
@@ -266,7 +266,7 @@ namespace images {
         return Py_None;
     }
 
-    PyObject * image_save_tile(PyObject *self, PyObject *args)
+    PyObject * image_save_tile([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyimwriter;
         if (!PyArg_ParseTuple(args, "O", &pyimwriter))
@@ -286,7 +286,7 @@ namespace images {
         return Py_None;
     }
 
-    PyObject * image_save_footer(PyObject *self, PyObject *args)
+    PyObject * image_save_footer([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyimwriter;
         if (!PyArg_ParseTuple(args, "O", &pyimwriter))
@@ -306,7 +306,7 @@ namespace images {
         return Py_None;
     }
 
-    PyObject * image_buffer(PyObject *self, PyObject *args)
+    PyObject * image_buffer([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyim;
         PyObject *pybuf;
@@ -334,7 +334,7 @@ namespace images {
             PyErr_SetString(PyExc_ValueError, "request for buffer outside image bounds");
             return NULL;
         }
-        int offset = 3 * (y * i->Xres() + x);
+        int offset = 3 * (y * i->Xres() + x); // @TODO: this number 3 means "bytes per pixel" and it's hardcoded here and in the image class
         assert(offset > -1 && offset < i->bytes());
         Py_buffer *buffer = new Py_buffer;
         PyBuffer_FillInfo(buffer, NULL, i->getBuffer() + offset, i->bytes() - offset, 0, PyBUF_WRITABLE);
@@ -345,7 +345,7 @@ namespace images {
         return pybuf;
     }
 
-    PyObject * image_fate_buffer(PyObject *self, PyObject *args)
+    PyObject * image_fate_buffer([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyim;
         PyObject *pybuf;
@@ -387,7 +387,7 @@ namespace images {
         return pybuf;
     }
 
-    PyObject * image_get_color_index(PyObject *self, PyObject *args)
+    PyObject * image_get_color_index([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyim;
 
@@ -419,7 +419,7 @@ namespace images {
         return Py_BuildValue("d", (double)dist);
     }
 
-    PyObject * image_get_fate(PyObject *self, PyObject *args)
+    PyObject * image_get_fate([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyim;
 
@@ -479,7 +479,7 @@ ImageWriter * image_writer_fromcapsule(PyObject *p)
     ImageWriter *iw = (ImageWriter *)PyCapsule_GetPointer(p, OBTYPE_IMAGE_WRITER);
     if (NULL == iw)
     {
-        fprintf(stderr, "%p : IW : BAD\n", p);
+        fprintf(stderr, "%p : IW : BAD\n", reinterpret_cast<void *>(p));
     }
 
     return iw;

--- a/fract4d/c/fract4dc/loaders.cpp
+++ b/fract4d/c/fract4dc/loaders.cpp
@@ -218,7 +218,7 @@ namespace loaders
         struct pfHandle *pfHandle = (struct pfHandle *)PyCapsule_GetPointer(capsule, OBTYPE_POINTFUNC);
         if (NULL == pfHandle)
         {
-            fprintf(stderr, "%p : PF : BAD\n", reinterpret_cast<void *>(capsule));
+            fprintf(stderr, "%p : PF : BAD\n", static_cast<void *>(capsule));
         }
         return pfHandle;
     }
@@ -251,7 +251,7 @@ namespace loaders
         void *vp = PyCapsule_GetPointer(p, OBTYPE_MODULE);
         if (NULL == vp)
         {
-            fprintf(stderr, "%p : SO : BAD\n", reinterpret_cast<void *>(p));
+            fprintf(stderr, "%p : SO : BAD\n", static_cast<void *>(p));
         }
 
         return vp;

--- a/fract4d/c/fract4dc/loaders.cpp
+++ b/fract4d/c/fract4dc/loaders.cpp
@@ -12,7 +12,7 @@
 namespace loaders
 {
 
-    PyObject *module_load(PyObject *self, PyObject *args)
+    PyObject *module_load([[maybe_unused]] PyObject *self, PyObject *args)
     {
     #ifdef STATIC_CALC
         Py_INCREF(Py_None);
@@ -39,7 +39,7 @@ namespace loaders
     #endif
     }
 
-    PyObject * pf_create(PyObject *self, PyObject *args)
+    PyObject * pf_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         struct pfHandle *pfh = (pfHandle *)malloc(sizeof(struct pfHandle));
         void *dlHandle;
@@ -81,7 +81,7 @@ namespace loaders
     }
 
 
-    PyObject * pf_init(PyObject *self, PyObject *args)
+    PyObject * pf_init([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyobj, *pyarray, *py_posparams;
         struct s_param *params;
@@ -122,7 +122,7 @@ namespace loaders
     }
 
 
-    PyObject * pf_defaults(PyObject *self, PyObject *args)
+    PyObject * pf_defaults([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyobj, *pyarray, *py_posparams;
         struct s_param *params;
@@ -167,7 +167,7 @@ namespace loaders
         return pyret;
     }
 
-    PyObject * pf_calc(PyObject *self, PyObject *args)
+    PyObject * pf_calc([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyobj, *pyret;
         double params[4];
@@ -218,7 +218,7 @@ namespace loaders
         struct pfHandle *pfHandle = (struct pfHandle *)PyCapsule_GetPointer(capsule, OBTYPE_POINTFUNC);
         if (NULL == pfHandle)
         {
-            fprintf(stderr, "%p : PF : BAD\n", capsule);
+            fprintf(stderr, "%p : PF : BAD\n", reinterpret_cast<void *>(capsule));
         }
         return pfHandle;
     }
@@ -251,7 +251,7 @@ namespace loaders
         void *vp = PyCapsule_GetPointer(p, OBTYPE_MODULE);
         if (NULL == vp)
         {
-            fprintf(stderr, "%p : SO : BAD\n", p);
+            fprintf(stderr, "%p : SO : BAD\n", reinterpret_cast<void *>(p));
         }
 
         return vp;

--- a/fract4d/c/fract4dc/pysite.cpp
+++ b/fract4d/c/fract4dc/pysite.cpp
@@ -133,7 +133,7 @@ bool PySite::is_interrupted()
     return ret;
 }
 
-// pixel changed
+#ifdef DEBUG_PIXEL
 void PySite::pixel_changed(
     const double *params, int maxIters, int nNoPeriodIters,
     int x, int y, int aa,
@@ -156,6 +156,7 @@ void PySite::pixel_changed(
         RELEASE_LOCK;
     }
 }
+#endif
 
 void PySite::interrupt()
 {

--- a/fract4d/c/fract4dc/pysite.h
+++ b/fract4d/c/fract4dc/pysite.h
@@ -16,11 +16,13 @@ public:
     void stats_changed(pixel_stat_t &stats);
     void status_changed(int status_val);
     bool is_interrupted();
+#ifdef DEBUG_PIXEL
     void pixel_changed(
         const double *params, int maxIters, int nNoPeriodIters,
         int x, int y, int aa,
         double dist, int fate, int nIters,
         int r, int g, int b, int a);
+#endif
     void interrupt();
     void start();
     ~PySite();

--- a/fract4d/c/fract4dc/sites.cpp
+++ b/fract4d/c/fract4dc/sites.cpp
@@ -7,7 +7,7 @@
 
 namespace sites {
 
-    PyObject * pyfdsite_create(PyObject *self, PyObject *args)
+    PyObject * pyfdsite_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         int fd;
         if (!PyArg_ParseTuple(args, "i", &fd))
@@ -22,7 +22,7 @@ namespace sites {
         return pyret;
     }
 
-    PyObject * pysite_create(PyObject *self, PyObject *args)
+    PyObject * pysite_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pysite;
         if (!PyArg_ParseTuple(
@@ -52,7 +52,7 @@ namespace sites {
         IFractalSite *site = (IFractalSite *)PyCapsule_GetPointer(pysite, OBTYPE_SITE);
         if (NULL == site)
         {
-            fprintf(stderr, "%p : ST : BAD\n", pysite);
+            fprintf(stderr, "%p : ST : BAD\n", reinterpret_cast<void *>(pysite));
         }
         return site;
     }

--- a/fract4d/c/fract4dc/sites.cpp
+++ b/fract4d/c/fract4dc/sites.cpp
@@ -52,7 +52,7 @@ namespace sites {
         IFractalSite *site = (IFractalSite *)PyCapsule_GetPointer(pysite, OBTYPE_SITE);
         if (NULL == site)
         {
-            fprintf(stderr, "%p : ST : BAD\n", reinterpret_cast<void *>(pysite));
+            fprintf(stderr, "%p : ST : BAD\n", static_cast<void *>(pysite));
         }
         return site;
     }

--- a/fract4d/c/fract4dc/utils.cpp
+++ b/fract4d/c/fract4dc/utils.cpp
@@ -13,7 +13,7 @@
 
 namespace utils {
 
-    PyObject * rot_matrix(PyObject *self, PyObject *args)
+    PyObject * rot_matrix([[maybe_unused]] PyObject *self, PyObject *args)
     {
         double params[N_PARAMS];
 
@@ -38,7 +38,7 @@ namespace utils {
     }
 
 
-    PyObject * eye_vector(PyObject *self, PyObject *args)
+    PyObject * eye_vector([[maybe_unused]] PyObject *self, PyObject *args)
     {
         double params[N_PARAMS], dist;
 
@@ -60,7 +60,7 @@ namespace utils {
     }
 
 
-    PyObject * pyrgb_to_hsv(PyObject *self, PyObject *args)
+    PyObject * pyrgb_to_hsv([[maybe_unused]] PyObject *self, PyObject *args)
     {
         double r, g, b, a = 1.0, h, s, v;
         if (!PyArg_ParseTuple(
@@ -78,7 +78,7 @@ namespace utils {
             h, s, v, a);
     }
 
-    PyObject * pyrgb_to_hsl(PyObject *self, PyObject *args)
+    PyObject * pyrgb_to_hsl([[maybe_unused]] PyObject *self, PyObject *args)
     {
         double r, g, b, a = 1.0, h, l, s;
         if (!PyArg_ParseTuple(
@@ -96,7 +96,7 @@ namespace utils {
             h, s, l, a);
     }
 
-    PyObject * pyhsl_to_rgb(PyObject *self, PyObject *args)
+    PyObject * pyhsl_to_rgb([[maybe_unused]] PyObject *self, PyObject *args)
     {
         double r, g, b, a = 1.0, h, l, s;
         if (!PyArg_ParseTuple(
@@ -115,7 +115,7 @@ namespace utils {
     }
 
 
-    PyObject * pyarray_get(PyObject *self, PyObject *args)
+    PyObject * pyarray_get([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyAllocation;
         int indexes[4];
@@ -146,7 +146,7 @@ namespace utils {
         return pyRet;
     }
 
-    PyObject * pyarray_set(PyObject *self, PyObject *args)
+    PyObject * pyarray_set([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyAllocation;
         int val;

--- a/fract4d/c/fract4dc/workers.cpp
+++ b/fract4d/c/fract4dc/workers.cpp
@@ -74,8 +74,13 @@ namespace workers {
             return NULL;
         }
 
-        IFractWorker *worker = fw_fromcapsule(pyworker);
-        worker->pixel(x, y, w, h);
+        if (STFractWorker *worker = dynamic_cast<STFractWorker *>(fw_fromcapsule(pyworker))) {
+            worker->pixel(x, y, w, h);
+        }
+        else
+        {
+            return NULL;
+        }
 
         Py_INCREF(Py_None);
         return Py_None;
@@ -93,8 +98,13 @@ namespace workers {
             return NULL;
         }
 
-        IFractWorker *worker = fw_fromcapsule(pyworker);
-        worker->pixel_aa(x, y);
+        if (STFractWorker *worker = dynamic_cast<STFractWorker *>(fw_fromcapsule(pyworker))) {
+            worker->pixel_aa(x, y);
+        }
+        else
+        {
+            return NULL;
+        }
 
         Py_INCREF(Py_None);
         return Py_None;
@@ -113,9 +123,15 @@ namespace workers {
             return NULL;
         }
 
-        IFractWorker *worker = fw_fromcapsule(pyworker);
         dvec4 root;
-        int ok = worker->find_root(eye, look, root);
+        int ok = false;
+        if (STFractWorker *worker = dynamic_cast<STFractWorker *>(fw_fromcapsule(pyworker))) {
+            ok = worker->find_root(eye, look, root);
+        }
+        else
+        {
+            return NULL;
+        }
 
         return Py_BuildValue(
             "i(dddd)",

--- a/fract4d/c/fract4dc/workers.cpp
+++ b/fract4d/c/fract4dc/workers.cpp
@@ -19,7 +19,7 @@ namespace workers {
         return worker;
     }
 
-    PyObject * fw_create(PyObject *self, PyObject *args)
+    PyObject * fw_create([[maybe_unused]] PyObject *self, PyObject *args)
     {
         int nThreads;
         pf_obj *pfo;
@@ -62,7 +62,7 @@ namespace workers {
         return pyret;
     }
 
-    PyObject * fw_pixel(PyObject *self, PyObject *args)
+    PyObject * fw_pixel([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyworker;
         int x, y, w, h;
@@ -86,7 +86,7 @@ namespace workers {
         return Py_None;
     }
 
-    PyObject * fw_pixel_aa(PyObject *self, PyObject *args)
+    PyObject * fw_pixel_aa([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyworker;
         int x, y;
@@ -110,7 +110,7 @@ namespace workers {
         return Py_None;
     }
 
-    PyObject * fw_find_root(PyObject *self, PyObject *args)
+    PyObject * fw_find_root([[maybe_unused]] PyObject *self, PyObject *args)
     {
         PyObject *pyworker;
         dvec4 eye, look;

--- a/fract4d/c/fract4dmodule.cpp
+++ b/fract4d/c/fract4dmodule.cpp
@@ -468,7 +468,7 @@ static PyMethodDef Custom_controller_methods[] = {
         "stop_calculating", (PyCFunction) Controller_stop_calculating, METH_NOARGS,
         "Gracefully stops calculation task"
     },
-    {NULL}  /* Sentinel */
+    {NULL, NULL, 0, NULL}  /* Sentinel */
 };
 
 static PyTypeObject ControllerType = {

--- a/fract4d/c/fract_stdlib.cpp
+++ b/fract4d/c/fract_stdlib.cpp
@@ -166,7 +166,7 @@ bool arena_add_page(arena_t arena)
     {
         newalloc[i].d = 0.0;
     }
-    arena->pages_left--;
+    --arena->pages_left;
     arena->base_allocation = newalloc;
     arena->free_slots = arena->page_size;
     arena->next_allocation = &(arena->base_allocation[1]);

--- a/fract4d/c/model/MTFractWorker.cpp
+++ b/fract4d/c/model/MTFractWorker.cpp
@@ -60,11 +60,6 @@ void MTFractWorker::row(int x, int y, int n)
     }
 }
 
-void MTFractWorker::box(int x, int y, int rsize)
-{
-    m_workers[0].box(x, y, rsize);
-}
-
 void MTFractWorker::box_row(int w, int y, int rsize)
 {
     if (m_threads)
@@ -87,15 +82,6 @@ void MTFractWorker::qbox_row(int w, int y, int rsize, int drawsize)
     {
         m_workers[0].qbox_row(w, y, rsize, drawsize);
     }
-}
-
-void MTFractWorker::pixel(int x, int y, int w, int h)
-{
-    m_workers[0].pixel(x, y, w, h);
-}
-
-void MTFractWorker::pixel_aa(int x, int y)
-{
 }
 
 void MTFractWorker::reset_counts()
@@ -165,9 +151,4 @@ void MTFractWorker::flush()
     {
         m_threads->flush();
     }
-}
-
-bool MTFractWorker::find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root)
-{
-    return m_workers[0].find_root(eye, look, root);
 }

--- a/fract4d/c/model/MTFractWorker.cpp
+++ b/fract4d/c/model/MTFractWorker.cpp
@@ -36,15 +36,15 @@ void MTFractWorker::set_context(IWorkerContext *context)
     }
 }
 
-void MTFractWorker::row_aa(int x, int y, int n)
+void MTFractWorker::row_aa(int y, int n)
 {
     if (m_threads && n > 8)
     {
-        send_row_aa(x, y, n);
+        send_row_aa(y, n);
     }
     else
     {
-        m_workers[0].row_aa(x, y, n);
+        m_workers[0].row_aa(y, n);
     }
 }
 
@@ -139,10 +139,10 @@ void MTFractWorker::send_box(int x, int y, int rsize)
     send_cmd(JOB_BOX, x, y, rsize);
 }
 
-void MTFractWorker::send_row_aa(int x, int y, int w)
+void MTFractWorker::send_row_aa(int y, int w)
 {
     //cout << "sent RAA" << y << "\n";
-    send_cmd(JOB_ROW_AA, x, y, w);
+    send_cmd(JOB_ROW_AA, 0, y, w);
 }
 
 void MTFractWorker::flush()

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -48,7 +48,7 @@ void STFractWorker::work(job_info_t &tdata)
         break;
     case JOB_ROW_AA:
         //printf("RAA(%d,%d,%d) [%x]\n",x,y,param,(unsigned int)pthread_self());
-        row_aa(tdata.x, tdata.y, tdata.param);
+        row_aa(tdata.y, tdata.param);
         nRows = 1;
         break;
     case JOB_QBOX_ROW:
@@ -64,9 +64,9 @@ void STFractWorker::work(job_info_t &tdata)
     m_context->progress_changed(new_progress);
 }
 
-void STFractWorker::row_aa(int x, int y, int w)
+void STFractWorker::row_aa(int y, int w)
 {
-    for (int x = 0; x < w; x++)
+    for (auto x = 0; x < w; x++)
     {
         pixel_aa(x, y);
     }

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -768,7 +768,7 @@ inline void STFractWorker::rectangle_with_iter(
     }
 }
 
-// @TODO: this is used for RENDER_THREE_D mode and seems to be unfinished or at leats worth to review
+// @TODO: this is used for RENDER_THREE_D mode and seems to be unfinished or at least worth to review
 bool STFractWorker::find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root)
 {
     const calc_options &options = m_context->get_options();

--- a/fract4d/c/model/STFractWorker.cpp
+++ b/fract4d/c/model/STFractWorker.cpp
@@ -66,7 +66,7 @@ void STFractWorker::work(job_info_t &tdata)
 
 void STFractWorker::row_aa(int y, int w)
 {
-    for (auto x = 0; x < w; x++)
+    for (auto x = 0; x < w; ++x)
     {
         pixel_aa(x, y);
     }
@@ -246,19 +246,19 @@ void STFractWorker::compute_stats(const dvec4 &pos, int iter, fate_t fate, int x
 {
     const calc_options &options = m_context->get_options();
     m_stats.s[ITERATIONS] += iter;
-    m_stats.s[PIXELS]++;
-    m_stats.s[PIXELS_CALCULATED]++;
+    ++m_stats.s[PIXELS];
+    ++m_stats.s[PIXELS_CALCULATED];
     if (fate & FATE_INSIDE)
     {
-        m_stats.s[PIXELS_INSIDE]++;
+        ++m_stats.s[PIXELS_INSIDE];
         if (iter < options.maxiter - 1)
         {
-            m_stats.s[PIXELS_PERIODIC]++;
+            ++m_stats.s[PIXELS_PERIODIC];
         }
     }
     else
     {
-        m_stats.s[PIXELS_OUTSIDE]++;
+        ++m_stats.s[PIXELS_OUTSIDE];
     }
     if (options.auto_deepen && m_stats.s[PIXELS] % AUTO_DEEPEN_FREQUENCY == 0)
     {
@@ -298,7 +298,7 @@ void STFractWorker::compute_auto_tolerance_stats(const dvec4 &pos, int iter, int
         {
             // current tolerance is too loose, we would get 1 more
             // pixel correct if we tightened it
-            m_stats.s[BETTER_TOLERANCE_PIXELS]++;
+            ++m_stats.s[BETTER_TOLERANCE_PIXELS];
         }
     }
     else
@@ -323,7 +323,7 @@ void STFractWorker::compute_auto_tolerance_stats(const dvec4 &pos, int iter, int
         if (temp_iter == -1)
         {
             // if we loosened, we'd get this pixel wrong
-            m_stats.s[WORSE_TOLERANCE_PIXELS]++;
+            ++m_stats.s[WORSE_TOLERANCE_PIXELS];
         }
     }
 }
@@ -335,7 +335,7 @@ void STFractWorker::compute_auto_deepen_stats(const dvec4 &pos, int iter, int x,
     {
         /* we would have got this wrong if we used
 	    * half as many iterations */
-        m_stats.s[WORSE_DEPTH_PIXELS]++;
+        ++m_stats.s[WORSE_DEPTH_PIXELS];
     }
     else if (iter == -1)
     {
@@ -356,7 +356,7 @@ void STFractWorker::compute_auto_deepen_stats(const dvec4 &pos, int iter, int x,
         if (temp_iter != -1)
         {
             /* we would have got this right if we used twice as many iterations */
-            m_stats.s[BETTER_DEPTH_PIXELS]++;
+            ++m_stats.s[BETTER_DEPTH_PIXELS];
         }
     }
 }
@@ -597,8 +597,8 @@ void STFractWorker::interpolate_row(int x, int y, int rsize)
         m_im->setIter(x2, y, predicted_iter);
         m_im->setFate(x2, y, 0, fate);
         m_im->setIndex(x2, y, 0, predicted_index);
-        m_stats.s[PIXELS]++;
-        m_stats.s[PIXELS_SKIPPED]++;
+        ++m_stats.s[PIXELS];
+        ++m_stats.s[PIXELS_SKIPPED];
     }
 }
 
@@ -651,11 +651,11 @@ inline void STFractWorker::check_guess(int x, int y, rgba_t pixel)
         &tpixel, &titer, &tindex, &tfate);
     if (tpixel == pixel)
     {
-        m_stats.s[PIXELS_SKIPPED_RIGHT]++;
+        ++m_stats.s[PIXELS_SKIPPED_RIGHT];
     }
     else
     {
-        m_stats.s[PIXELS_SKIPPED_WRONG]++;
+        ++m_stats.s[PIXELS_SKIPPED_WRONG];
     }
 }
 #endif // #ifdef EXPERIMENTAL_OPTIMIZATIONS
@@ -726,9 +726,9 @@ void STFractWorker::box(int x, int y, int rsize)
 
 inline void STFractWorker::rectangle(rgba_t pixel, int x, int y, int w, int h)
 {
-    for (auto i = y; i < y + h; i++)
+    for (auto i = y; i < y + h; ++i)
     {
-        for (auto j = x; j < x + w; j++)
+        for (auto j = x; j < x + w; ++j)
         {
             m_im->put(j, i, pixel);
         }
@@ -739,9 +739,9 @@ inline void STFractWorker::rectangle_with_iter(
     rgba_t pixel, fate_t fate, int iter, float index,
     int x, int y, int w, int h)
 {
-    for (auto i = y; i < y + h; i++)
+    for (auto i = y; i < y + h; ++i)
     {
-        for (auto j = x; j < x + w; j++)
+        for (auto j = x; j < x + w; ++j)
         {
             if (m_context->get_debug_flags() & DEBUG_DRAWING_STATS)
             {
@@ -752,8 +752,8 @@ inline void STFractWorker::rectangle_with_iter(
             m_im->setIter(j, i, iter);
             m_im->setFate(j, i, 0, fate);
             m_im->setIndex(j, i, 0, index);
-            m_stats.s[PIXELS]++;
-            m_stats.s[PIXELS_SKIPPED]++;
+            ++m_stats.s[PIXELS];
+            ++m_stats.s[PIXELS_SKIPPED];
         }
     }
 }
@@ -791,7 +791,7 @@ bool STFractWorker::find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root)
             options.warp_param,
             x, y, 0,
             &pixel, &iter, &index, &fate);
-        steps++;
+        ++steps;
         if (fate != 0) // FIXME
         {
             // inside
@@ -826,7 +826,7 @@ bool STFractWorker::find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root)
             //outside, root must be further in
             lastdist = mid;
         }
-        steps++;
+        ++steps;
     }
 #ifdef DEBUG_ROOTS
     printf("polished after %d\n", steps);

--- a/fract4d/c/model/fractfunc.cpp
+++ b/fract4d/c/model/fractfunc.cpp
@@ -248,14 +248,14 @@ void fractFunc::draw(int rsize, int drawsize, float min_progress, float max_prog
     set_progress_range(min_progress, mid_progress);
 
     // first pass - big blocks and edges
-    int y = 0;
+    auto y = 0;
     while(y < h) {
         if ((h - y) > rsize) {
             m_worker->qbox_row(w, y, rsize, drawsize);
             y += rsize;
         } else {
             m_worker->row(0, y, w);
-            y++;
+            ++y;
         }
         if (update_image(y)) {
             break;

--- a/fract4d/c/model/fractfunc.cpp
+++ b/fract4d/c/model/fractfunc.cpp
@@ -107,7 +107,7 @@ void fractFunc::draw_aa(float min_progress, float max_progress)
 
         for (int y = i; y < h; y += 2)
         {
-            m_worker->row_aa(0, y, w);
+            m_worker->row_aa(y, w);
             if (update_image(y))
             {
                 break;

--- a/fract4d/c/model/image.cpp
+++ b/fract4d/c/model/image.cpp
@@ -55,26 +55,17 @@ void image::delete_buffers()
 
 bool image::alloc_buffers()
 {
+    // @TODO: find a way to reduce memory usage when (m_Xres * m_Yres > MAX_RECOLOR_SIZE)
     buffer = new (std::nothrow) char[bytes()];
     iter_buf = new (std::nothrow) int[m_Xres * m_Yres];
-    // FIXME remove true
-    if (true || m_Xres * m_Yres <= MAX_RECOLOR_SIZE)
-    {
-        index_buf = new (std::nothrow) float[m_Xres * m_Yres * N_SUBPIXELS];
-        fate_buf = new (std::nothrow) fate_t[m_Xres * m_Yres * N_SUBPIXELS];
-        if (!index_buf || !fate_buf)
-        {
-            delete_buffers();
-            return false;
-        }
-    }
-    else
-    {
-        // use less memory for big images. Sadly not working yet
-        index_buf = NULL;
-        fate_buf = NULL;
-    }
     if (!buffer || !iter_buf)
+    {
+        delete_buffers();
+        return false;
+    }
+    index_buf = new (std::nothrow) float[m_Xres * m_Yres * N_SUBPIXELS];
+    fate_buf = new (std::nothrow) fate_t[m_Xres * m_Yres * N_SUBPIXELS];
+    if (!index_buf || !fate_buf)
     {
         delete_buffers();
         return false;

--- a/fract4d/c/model/imagereader.cpp
+++ b/fract4d/c/model/imagereader.cpp
@@ -53,12 +53,12 @@ image_reader::image_reader(FILE *fp_, IImage *image_)
 
 #ifdef PNG_ENABLED
 
-void user_error_fn(png_structp png_ptr, png_const_charp error_msg)
+void user_error_fn([[maybe_unused]] png_structp png_ptr, png_const_charp error_msg)
 {
     printf("Error %s reading PNG file", error_msg);
 }
 
-void user_warning_fn(png_structp png_ptr, png_const_charp warning_msg)
+void user_warning_fn([[maybe_unused]] png_structp png_ptr, png_const_charp warning_msg)
 {
     printf("Warning %s reading PNG file", warning_msg);
 }

--- a/fract4d/c/model/imagereader.cpp
+++ b/fract4d/c/model/imagereader.cpp
@@ -112,10 +112,10 @@ bool png_reader::read_header()
 
 bool png_reader::read_tile()
 {
-    int number_passes = png_set_interlace_handling(png_ptr);
-    for (int pass = 0; pass < number_passes; pass++)
+    auto number_passes = png_set_interlace_handling(png_ptr);
+    for (auto pass = 0; pass < number_passes; ++pass)
     {
-        for (int y = 0; y < im->Yres(); y++)
+        for (auto y = 0; y < im->Yres(); ++y)
         {
             png_bytep row = (png_bytep)(im->getBuffer() + im->row_length() * y);
             png_read_rows(png_ptr, &row, (png_bytepp)NULL, 1);

--- a/fract4d/c/model/imagewriter.cpp
+++ b/fract4d/c/model/imagewriter.cpp
@@ -80,9 +80,9 @@ bool tga_writer::save_header()
 
 bool tga_writer::save_tile()
 {
-    for (int y = 0; y < im->Yres(); y++)
+    for (auto y = 0; y < im->Yres(); ++y)
     {
-        for (int x = 0; x < im->Xres(); x++)
+        for (int x = 0; x < im->Xres(); ++x)
         {
             rgba_t pixel = im->get(x, y);
             std::fputc(pixel.b, fp);
@@ -164,7 +164,7 @@ bool png_writer::save_header()
 
 bool png_writer::save_tile()
 {
-    for (int y = 0; y < im->Yres(); y++)
+    for (auto y = 0; y < im->Yres(); ++y)
     {
         png_bytep row = (png_bytep)(im->getBuffer() + im->row_length() * y);
         png_write_rows(png_ptr, &row, 1);
@@ -207,7 +207,7 @@ bool jpg_writer::save_header()
 
 bool jpg_writer::save_tile()
 {
-    for (int y = 0; y < im->Yres(); y++)
+    for (auto y = 0; y < im->Yres(); ++y)
     {
         JSAMPROW row = (JSAMPROW)(im->getBuffer() + im->row_length() * y);
         jpeg_write_scanlines(&cinfo, &row, 1);

--- a/fract4d/c/model/site.cpp
+++ b/fract4d/c/model/site.cpp
@@ -99,7 +99,7 @@ bool FDSite::is_interrupted()
     return interrupted;
 }
 
-// pixel changed
+#ifdef DEBUG_PIXEL
 void FDSite::pixel_changed(
     const double *params, int maxIters, int nNoPeriodIters,
     int x, int y, int aa,
@@ -113,6 +113,7 @@ void FDSite::pixel_changed(
     */
     return; // FIXME
 }
+#endif
 
 void FDSite::interrupt()
 {

--- a/fract4d/c/model/site.h
+++ b/fract4d/c/model/site.h
@@ -34,12 +34,14 @@ public:
     virtual void status_changed(int status_val) = 0;
     // statistics about image
     virtual void stats_changed(pixel_stat_t &stats) = 0;
+#ifdef DEBUG_PIXEL
     // per-pixel callback for debugging
     virtual void pixel_changed(
         const double *params, int maxIters, int min_period_iter,
         int x, int y, int aa,
         double dist, int fate, int nIters,
         int r, int g, int b, int a) = 0;
+#endif
     // asynchronous support
     // return true if we've been interrupted and are supposed to stop
     virtual bool is_interrupted() = 0;
@@ -67,11 +69,13 @@ public:
     void stats_changed(pixel_stat_t &stats);
     void status_changed(int status_val);
     bool is_interrupted();
+#ifdef DEBUG_PIXEL
     void pixel_changed(
         const double *params, int maxIters, int nNoPeriodIters,
         int x, int y, int aa,
         double dist, int fate, int nIters,
         int r, int g, int b, int a);
+#endif
     void interrupt();
     void start();
     ~FDSite();

--- a/fract4d/c/model/threadpool.h
+++ b/fract4d/c/model/threadpool.h
@@ -125,8 +125,8 @@ public:
         /* advance queue head to next position */
         queue_head = (queue_head + 1) % max_queue_size;
         /* record keeping */
-        cur_queue_size++;
-        work_queued++;
+        ++cur_queue_size;
+        ++work_queued;
         if (1 == cur_queue_size)
         {
             pthread_cond_broadcast(&queue_not_empty);
@@ -141,7 +141,7 @@ public:
         while (1)
         {
             pthread_mutex_lock(&queue_lock);
-            total_work_done++;
+            ++total_work_done;
             while (cur_queue_size == 0 && !(shutdown))
             {
                 if (total_work_done == target_work_done)
@@ -156,7 +156,7 @@ public:
                 pthread_exit(NULL);
             }
             tpool_work<work_t, threadInfo> *my_workp = &queue[queue_tail];
-            cur_queue_size--;
+            --cur_queue_size;
             assert(cur_queue_size >= 0);
             queue_tail = (queue_tail + 1) % max_queue_size;
             if (cur_queue_size == max_queue_size - 1)

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -141,7 +141,7 @@ private:
     void rectangle(rgba_t, int x, int y, int w, int h);
     void rectangle_with_iter(rgba_t, fate_t, int iter, float index, int x, int y, int w, int h);
 
-    // EXPERIMENTAL (not in use)
+#ifdef EXPERIMENTAL_OPTIMIZATIONS
     // is the square with its top-left corner at (x,y) close-enough to flat
     // that we could interpolate & get a decent-looking image?
     bool isNearlyFlat(int x, int y, int rsize);
@@ -152,12 +152,13 @@ private:
     void interpolate_rectangle(int x, int y, int rsize);
     void interpolate_row(int x, int y, int rsize);
     // compare a prediction against the real answer & update stats
-    void check_guess(int x, int y, rgba_t pixel, fate_t fate, int iter, float index);
+    void check_guess(int x, int y, rgba_t pixel);
     // sum squared differences between components of 2 colors
     int diff_colors(rgba_t a, rgba_t b);
+#endif // #ifdef EXPERIMENTAL_OPTIMIZATIONS
 
     // @TODO: move m_site and m_im dependencies to IWorkerContext
-    IFractalSite *m_site;
+    [[maybe_unused]] IFractalSite *m_site;
     IWorkerContext *m_context;
     /* pointers to data also held in fractFunc */
     IImage *m_im;

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -73,7 +73,7 @@ public:
 
     virtual void set_context(IWorkerContext *) = 0;
     // calculate a row of antialiased pixels
-    virtual void row_aa(int x, int y, int n) = 0;
+    virtual void row_aa(int y, int n) = 0;
     // calculate a row of pixels
     virtual void row(int x, int y, int n) = 0;
     // calculate a row of boxes
@@ -103,7 +103,7 @@ public:
 
     // IFractWorker interface
     void set_context(IWorkerContext *);
-    void row_aa(int x, int y, int n);
+    void row_aa(int y, int n);
     void row(int x, int y, int n);
     void box_row(int w, int y, int rsize);
     void qbox_row(int w, int y, int rsize, int drawsize);
@@ -184,7 +184,7 @@ public:
 
     // IFractWorker interface
     void set_context(IWorkerContext *);
-    void row_aa(int x, int y, int n);
+    void row_aa(int y, int n);
     void row(int x, int y, int n);
     void qbox_row(int w, int y, int rsize, int drawsize);
     void box_row(int w, int y, int rsize);
@@ -198,7 +198,7 @@ private:
     void send_quit();
     void send_box(int x, int y, int rsize);
     void send_row(int x, int y, int n);
-    void send_row_aa(int x, int y, int n);
+    void send_row_aa(int y, int n);
     void send_box_row(int w, int y, int rsize);
     void send_qbox_row(int w, int y, int rsize, int drawsize);
 

--- a/fract4d/c/model/worker.h
+++ b/fract4d/c/model/worker.h
@@ -76,21 +76,13 @@ public:
     virtual void row_aa(int x, int y, int n) = 0;
     // calculate a row of pixels
     virtual void row(int x, int y, int n) = 0;
-    // calculate an rsize-by-rsize box of pixels
-    virtual void box(int x, int y, int rsize) = 0;
     // calculate a row of boxes
     virtual void box_row(int w, int y, int rsize) = 0;
     // calculate a row of boxes, quickly
     virtual void qbox_row(int w, int y, int rsize, int drawsize) = 0;
-    // calculate a single pixel
-    virtual void pixel(int x, int y, int w, int h) = 0;
-    // calculate a single pixel in aa-mode
-    virtual void pixel_aa(int x, int y) = 0;
     // auto-deepening record keeping
     virtual void reset_counts() = 0;
     virtual const pixel_stat_t &get_stats() const = 0;
-    // ray-tracing machinery
-    virtual bool find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root) = 0;
     virtual void flush() = 0;
 
     virtual ~IFractWorker() = default;
@@ -111,19 +103,23 @@ public:
 
     // IFractWorker interface
     void set_context(IWorkerContext *);
-
     void row_aa(int x, int y, int n);
     void row(int x, int y, int n);
-    void box(int x, int y, int rsize);
     void box_row(int w, int y, int rsize);
     void qbox_row(int w, int y, int rsize, int drawsize);
-    void pixel(int x, int y, int h, int w);
-    void pixel_aa(int x, int y);
     void reset_counts();
     const pixel_stat_t &get_stats() const;
-    bool find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root);
     void flush(){};
 
+    // @TODO: make these private
+    // calculate an rsize-by-rsize box of pixels
+    void box(int x, int y, int rsize);
+    // calculate a single pixel
+    void pixel(int x, int y, int h, int w);
+    // calculate a single pixel in aa-mode
+    void pixel_aa(int x, int y);
+    // ray-tracing machinery
+    bool find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root);
 private:
     void compute_stats(const dvec4 &pos, int iter, fate_t, int x, int y);
     void compute_auto_deepen_stats(const dvec4 &pos, int iter, int x, int y);
@@ -190,14 +186,10 @@ public:
     void set_context(IWorkerContext *);
     void row_aa(int x, int y, int n);
     void row(int x, int y, int n);
-    void box(int x, int y, int rsize);
     void qbox_row(int w, int y, int rsize, int drawsize);
     void box_row(int w, int y, int rsize);
-    void pixel(int x, int y, int h, int w);
-    void pixel_aa(int x, int y);
     void reset_counts();
     const pixel_stat_t &get_stats() const;
-    bool find_root(const dvec4 &eye, const dvec4 &look, dvec4 &root);
     void flush();
 
 private:

--- a/fract4d/fractconfig.py
+++ b/fract4d/fractconfig.py
@@ -160,7 +160,7 @@ class T(configparser.ConfigParser):
 
     def get_default_compiler_options(self):
         # appears to work for most unixes
-        return "-fPIC -DPIC -D_REENTRANT -O2 -shared -ffast-math"
+        return "-fPIC -DPIC -O2 -shared -ffast-math"
 
     def set(self, section, key, val):
         if self.has_section(section) and \
@@ -266,7 +266,7 @@ class DarwinConfig(T):
         return "open %s"
 
     def get_default_compiler_options(self):
-        return "-fPIC -DPIC -D_REENTRANT -O2 -dynamiclib -flat_namespace -undefined suppress -ffast-math"
+        return "-fPIC -DPIC -O2 -dynamiclib -flat_namespace -undefined suppress -ffast-math"
 
 
 def userConfig():

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,6 @@ fract4d_sources = [
 ]
 
 defines = [
-    ('_REENTRANT', 1),
     ('THREADS', 1),
     # ('STATIC_CALC',1),
     # ('NO_CALC', 1),  # set this to not calculate the fractal

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ _DEBUG = False
 
 if sys.version_info < (3, 6):
     print("Sorry, you need Python 3.6 or higher to run Gnofract 4D.")
-    print("You have version {sys.version}. Please upgrade.")
+    print("You have version %s. Please upgrade." % sys.version)
     sys.exit(1)
 
 if not os.path.exists(os.path.join(sysconfig.get_config_var("INCLUDEPY"), "Python.h")):

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ png_flags = call_package_config("libpng", "--cflags")
 png_libs = call_package_config("libpng", "--libs")
 define_macros = [('PNG_ENABLED', 1)]
 
-jpeg_flags = call_package_config("libjpeg", "--cflags")
-jpeg_libs = call_package_config("libjpeg", "--libs")
+jpeg_flags = call_package_config("libjpeg", "--cflags", True)
+jpeg_libs = call_package_config("libjpeg", "--libs", True)
 if jpeg_flags + jpeg_libs:
     define_macros.append(('JPG_ENABLED', 1))
 

--- a/setup.py
+++ b/setup.py
@@ -111,10 +111,12 @@ defines = [
     # ('NO_CALC', 1),  # set this to not calculate the fractal
     # ('DEBUG_CREATION',1), # debug spew for allocation of objects
     # ('DEBUG_ALLOCATION',1), # debug spew for array handling
+    # ('DEBUG_PIXEL',1), # debug spew for array handling
+    # ('EXPERIMENTAL_OPTIMIZATIONS',1), # enables some experimental optimizations
 ]
 
 libraries = ['stdc++']
-extra_compile_args = ['-Wall', '-O0', '-std=c++17'] + png_flags
+extra_compile_args = ['-std=c++17', '-Wall', '-Wextra', '-Wpedantic'] + png_flags
 define_macros = defines + extra_macros
 
 module_fract4dc = Extension(
@@ -124,7 +126,8 @@ module_fract4dc = Extension(
     libraries=libraries + jpg_libs,
     extra_compile_args=extra_compile_args,
     extra_link_args=png_libs,
-    define_macros=define_macros
+    define_macros=define_macros,
+    # undef_macros=['NDEBUG'], # you need this to enable asserts
 )
 
 modules = [module_fract4dc]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ gnofract4d_version = '4.2'
 
 if sys.version_info < (3, 6):
     print("Sorry, you need Python 3.6 or higher to run Gnofract 4D.")
-    print("You have version %s. Please upgrade." % sys.version)
+    print("You have version {sys.version}. Please upgrade.")
     sys.exit(1)
 
 if not os.path.exists(os.path.join(sysconfig.get_config_var("INCLUDEPY"), "Python.h")):
@@ -30,14 +30,12 @@ os.environ["OPT"] = sysconfig.get_config_var(
 # Extensions need to link against appropriate libs
 # We use pkg-config to find the appropriate set of includes and libs
 def call_package_config(package, option, optional=False):
-    '''invoke pkg-config, if it exists, to find the appropriate
-    arguments for a library'''
+    '''invoke pkg-config, if it exists, to find the appropriate arguments for a library'''
     try:
         cp = subprocess.run(["pkg-config", package, option],
                             universal_newlines=True, stdout=subprocess.PIPE)
     except FileNotFoundError:
-        print("Unable to check for %s, pkg-config not installed" %
-              package, file=sys.stderr)
+        print(f"Unable to check for '{package}', pkg-config not installed", file=sys.stderr)
         if optional:
             return []
         else:
@@ -45,12 +43,11 @@ def call_package_config(package, option, optional=False):
 
     if cp.returncode != 0:
         if optional:
-            print("Can't find '%s'" % package, file=sys.stderr)
+            print(f"Can't find '{package}'", file=sys.stderr)
             print("Some functionality will be disabled", file=sys.stderr)
             return []
         else:
-            print("Development files not found for: '%s'." %
-                  package, file=sys.stderr)
+            print(f"Development files not found for '{package}'", file=sys.stderr)
             sys.exit(1)
 
     return cp.stdout.split()
@@ -137,8 +134,8 @@ def get_files(dir, ext):
 def get_icons():
     icons = []
     for size in 16, 32, 48, 64, 128, 256:
-        icons.append(('share/icons/hicolor/{0}x{0}/apps'.format(size),
-            ['pixmaps/logo/{0}x{0}/gnofract4d.png'.format(size)]))
+        icons.append((f'share/icons/hicolor/{size}x{size}/apps',
+            [f'pixmaps/logo/{size}x{size}/gnofract4d.png']))
     return icons
 
 so_extension = sysconfig.get_config_var("EXT_SUFFIX")


### PR DESCRIPTION
So I started this to clean up some unneeded code in the workers, but then I got enthused and ended up adding some extra cleanings and tidying up:
- removed `_REENTRANT` define (see https://stackoverflow.com/questions/2601753/what-is-the-reentrant-flag)
> So it seems like _REENTRANT is mostly a no-op, these days. It might once have declared a lot of new functions, such as strtok_r; but these days those functions are mostly mandated by various decades-old standards (C99, POSIX 95, POSIX.1-2001, etc.) and so they're just always enabled.
- conditionally compile the experimental code in `STFractWorker`
- conditionally compile the `pixel_changed` callback interface for `Site` (this is meant for debug purposes only)
- narrow down the public interface of the `IFractWorker`
- added some extra warnings for compiling the **fract4dc** module: those helped me out to detect code smells tackled in this PR
- silenced some of the above warnings fixing them up or with C++ attributes
- drop support for **python 3.5** in the docker scripts
- by the way `setup.py` has been updated with f-strings 
- `setup.py `now uses `pkg_config` to link `libjpeg`
- added a debug mode to the `setup.py`: now **-O0** is no longer the default optimization level

Sorry to mix things up, hope you can have a look with no much trouble.