### PR TITLE
Remove unsupported Python 3.5 from docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 # bin/run_builds.sh deps
 RUN apt-get -y install software-properties-common && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get -y install python3.5 python3.5-dev python3.6 python3.6-dev python3.7 python3.7-dev python3.8 python3.8-dev
+    apt-get -y install python3.6 python3.6-dev python3.7 python3.7-dev python3.8 python3.8-dev
 
 # bin/run_pylint.sh deps
 RUN pip3 install pylint

--- a/docker/bin/run_builds.sh
+++ b/docker/bin/run_builds.sh
@@ -2,8 +2,7 @@
 
 docker-compose up -d --build
 docker-compose exec server bash -c "rm -rf build"
-docker-compose exec server bash -c "python3.5 ./setup.py build && \
-                                    python3.6 ./setup.py build && \
+docker-compose exec server bash -c "python3.6 ./setup.py build && \
                                     python3.7 ./setup.py build && \
                                     python3.8 ./setup.py build"
 docker-compose down

--- a/docker/bin/run_tox.sh
+++ b/docker/bin/run_tox.sh
@@ -2,8 +2,7 @@
 
 docker-compose up -d --build
 docker-compose exec server bash -c "rm -rf build"
-docker-compose exec server bash -c "python3.5 ./setup.py build && \
-                                    python3.6 ./setup.py build && \
+docker-compose exec server bash -c "python3.6 ./setup.py build && \
                                     python3.7 ./setup.py build && \
                                     python3.8 ./setup.py build && \
                                     tox"


### PR DESCRIPTION
Python 3.6 is the minimum since:
82522d4 ("update min python to 3.6  (#143)", 2020-07-03)