### PR TITLE
Only run workflow on pushes to master and PR synchronize

### DIFF
--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -2,8 +2,9 @@ name: Test Gnofract 4D
 
 on:
     pull_request:
-      types: [opened, reopened, ready_for_review]
+      types: [opened, reopened, ready_for_review, synchronize]
     push:
+      branches: ["master"]
 
 jobs:
   run:


### PR DESCRIPTION
synchronize seems to be the best event for running PRs on changes (it is actually the default). GitHub does now seem to be deduplicating the Pushes/PRs? (not a bad idea to tidy up anyway) but it doesn't catch force pushes.
