### PR TITLE
Tidy Dockerfile and add support for Gio.AppInfo.launch_default_for_uri()

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,9 @@ RUN \
     add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get -y install python3.6-dev python3.7-dev python3.8-dev
 
+# Gio.AppInfo.launch_default_for_uri() deps
+RUN apt-get -y install firefox gvfs
+
 # bin/run_pylint.sh deps
 RUN pip3 install pylint
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN \
     apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install libpng-dev libjpeg-dev gtk3.0 libcairo2-dev python3-cairo python3-gi-cairo pkg-config python3-pip xvfb
+    apt-get -y install gir1.2-gtk-3.0 libjpeg-dev libpng-dev pkg-config python3-gi-cairo python3-pip xvfb
 
 # bin/run_builds.sh deps
 RUN \
@@ -23,7 +23,7 @@ RUN pip3 install pylint
 RUN pip3 install pytest
 
 # bin/run_tox.sh deps
-RUN apt-get -y install libgirepository1.0-dev
+RUN apt-get -y install libcairo2-dev libgirepository1.0-dev
 RUN pip3 install tox
 
 # Xvfb (in memory x11 server) setup

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,14 +7,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN \
     apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install libpng-dev libjpeg-dev python3-dev gtk3.0 libcairo2-dev python3-cairo python3-gi-cairo pkg-config python3-pip xvfb
+    apt-get -y install libpng-dev libjpeg-dev gtk3.0 libcairo2-dev python3-cairo python3-gi-cairo pkg-config python3-pip xvfb
 
 # bin/run_builds.sh deps
 RUN \
     apt-get update && \
     apt-get -y install software-properties-common && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get -y install python3.6 python3.6-dev python3.7 python3.7-dev python3.8 python3.8-dev
+    apt-get -y install python3.6-dev python3.7-dev python3.8-dev
 
 # bin/run_pylint.sh deps
 RUN pip3 install pylint


### PR DESCRIPTION
This results in a Docker image that is about 200MB smaller for me (gtk3.0 seemed to be interpreted as something that needed every mono package going!) and supports the new way of launching a browser.
