### PR TITLE
No need to stop unused yelp at the end of MainWindow tests

### DIFF
--- a/fract4dgui/tests/test_main_window.py
+++ b/fract4dgui/tests/test_main_window.py
@@ -28,10 +28,6 @@ class Test(testgui.TestCase):
         self.mw = WrapMainWindow(Test.userConfig)
         self.assertEqual(self.mw.filename, None, "shouldn't have a filename")
 
-    def tearDown(self):
-        os.system("killall realyelp > /dev/null 2>&1")
-        os.system("killall yelp > /dev/null 2>&1")
-
     def wait(self):
         Gtk.main()
 


### PR DESCRIPTION
Leftover from the switch from yelp to html only for the manual.
