### PR TITLE
Change Codecov GitHub Action dependency to v1

### DIFF
--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install MacOS packages
+      - name: Install macOS packages
         if: ${{ runner.os == 'macOS' }}
         run: brew install gtk+3 pygobject3
       - name: Install Ubuntu packages
@@ -46,7 +46,7 @@ jobs:
         run: pip install tox
       - name: Build
         run: python setup.py build
-      - name: Run Tox (MacOS)
+      - name: Run Tox (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: tox -e ${{ matrix.toxenv }}
       - name: Run Tox (Linux)

--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -54,7 +54,7 @@ jobs:
         run: xvfb-run --auto-servernum tox -e ${{ matrix.toxenv }}
       - name: Upload coverage to Codecov
         if: ${{ matrix.toxenv == 'py' }}
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
           env_vars: OS,PYTHON

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ On Ubuntu, these can be installed with:
 
 If FFmpeg is installed it will be possible to create videos.
 
-On MacOS, you can install the dependencies using brew:
+On macOS, you can install the dependencies using brew:
 
     brew install librsvg python3 pkg-config cairo gtk+3 pygobject3 py3cairo libpng jpeg
 
@@ -74,7 +74,7 @@ Run individual tests from the top-level directory using pytest, e.g.:
 Optionally, install tox and test with all supported Python versions by running:
     tox
 
-On MacOS you might find an error regarding the number of opened files, you can increase the system limit with `ulimit -Sn 10000`
+On macOS you might find an error regarding the number of opened files, you can increase the system limit with `ulimit -Sn 10000`
 
 Linting
 =======
@@ -100,5 +100,5 @@ You can only regenerate the docs if you clone the Gnofract 4D git repo - the sou
 2. The documentation theme is managed in a separate repository and embedded in manual/themes/book as a submodule. Initialize and update it with `git submodule update --init`
 3. Install hugo
     * Ubuntu 18.04 has an older version. Run `snap install hugo --channel=extended` instead of `apt install hugo`
-    * For MacOS you can install with `brew install hugo`
+    * For macOS you can install with `brew install hugo`
 4. Run `./createdocs.py`


### PR DESCRIPTION
An upgrade to v1.0.12 at the current time.

----

The v1 tag has to be moved manually in the Codecov repository, when we started using Actions it was pointing at an old version. So, this is an upgrade now and hopefully will move with new major releases in future. We haven't been getting the reports added to our PRs - will this fix it?

(And a documentation commit for macOS)
