### PR TITLE
Hold the GIL while deleting python objects

### DIFF
--- a/fract4d/c/fract4dc/calcs.cpp
+++ b/fract4d/c/fract4dc/calcs.cpp
@@ -94,7 +94,9 @@ void * calculation_thread(calc_args *args)
 #ifdef DEBUG_THREADS
     std::cerr << args << " : CA : ENDCALC(" << std::this_thread::get_id() << ")\n";
 #endif
+    PyGILState_STATE gstate = PyGILState_Ensure();
     delete args;
+    PyGILState_Release(gstate);
     return NULL;
 }
 


### PR DESCRIPTION
This code is in a thread not created by python, so it does not acquire the GIL by default.  The delete statement in question drops references to multiple python objects, possibly causing them to be deallocated while not holding the GIL.  This appears to be the direct cause of https://github.com/fract4d/gnofract4d/issues/164.