### PR TITLE
Fix inconsistent test coverage due to use of random()

### DIFF
--- a/fract4d/tests/test_formsettings.py
+++ b/fract4d/tests/test_formsettings.py
@@ -2,6 +2,7 @@
 
 import io
 import copy
+from unittest.mock import patch
 
 from . import testbase
 
@@ -149,11 +150,14 @@ class Test(testbase.ClassSetup):
 
         self.assertEqual(4.0, fs1.get_named_param_value("@bailout"))
 
-    def testMutate(self):
-        fs1 = formsettings.T(Test.g_comp)
-        fs1.set_formula("gf4d.frm", "Mandelbrot", g_grad)
+    @patch("random.random")
+    def testMutate(self, mock_random):
+        mock_random.return_value = 0.01
 
-        fs1.mutate(0.0, 1.0)
+        fs1 = formsettings.T(Test.g_comp)
+        fs1.set_formula("test.frm", "test_all_types", g_grad)
+
+        fs1.mutate(0.6, 1.0)
 
     def testNudge(self):
         fs1 = formsettings.T(Test.g_comp)

--- a/fract4d/tests/test_gradient.py
+++ b/fract4d/tests/test_gradient.py
@@ -747,6 +747,30 @@ opacity:
         self.assertEqual(False, g.set_color(-1, True, 0.2, 0.7, 0.9))
         self.assertEqual(False, g.set_color(7, True, 0.2, 0.7, 0.9))
 
+    def testRGBtoHSV(self):
+        rgb_hsv = (
+            ([0, 0, 0 ,0], [300, 0, 0, 0]),
+            ([1, 0, 0, 1], [0.0, 1.0, 1, 1]),
+            ([0, 0.5, 0, 1], [120.0, 1.0, 0.5, 1]),
+            ([0.5, 0.5, 1, 1], [240.0, 0.5, 1, 1]),
+        )
+        for rgb, hsv in rgb_hsv:
+            self.assertEqual(gradient.RGBtoHSV(rgb), hsv)
+
+    def testHSVtoRGB(self):
+        rgb_hsv = (
+            ([0, 0, 0], [300, 0, 0, 0]),
+            ([1, 0, 0, 1], [0.0, 1.0, 1, 1]),
+            ([0.75, 0.75, 0, 1], [60.0, 1.0, 0.75, 1]),
+            ([0, 0.5, 0, 1], [120.0, 1.0, 0.5, 1]),
+            ([0.5, 1, 1, 1], [180.0, 0.5, 1, 1]),
+            ([0.5, 0.5, 1, 1], [240.0, 0.5, 1, 1]),
+            ([0.75, 0.25, 0.75, 1], [300.0, 0.666666666667, 0.75, 1]),
+        )
+        for rgb, hsv in rgb_hsv:
+            self.assertNearlyEqual(
+                gradient.HSVtoRGB(hsv), rgb, f"HSV {hsv} expected RGB {rgb}")
+
     def assertNearlyEqual(self, a, b, msg, epsilon=1.0e-12):
         # check that each element is within epsilon of expected value
         for (ra, rb) in zip(a, b):


### PR DESCRIPTION
Directly test RGBtoHSV() and HSVtoRGB().
Use a formula with all parameter types and mock random() to fully test
formsettings mutate().

---

Based on the codecov results from #170, maybe there are others.
