### PR TITLE
Make testFDSite more robust by limiting message bytes read

### DIFF
--- a/fract4d/tests/test_fract4d.py
+++ b/fract4d/tests/test_fract4d.py
@@ -576,7 +576,7 @@ class Test(testbase.ClassSetup):
                     # wait up to 1 sec until we can read, otherwise we assume the counterpart is gone (an error ocurred on the C++ layer)
                     r, w, e = select.select([rfd], [], [], 1)
                     if rfd in r:
-                        temp = os.read(rfd, nb)
+                        temp = os.read(rfd, nb - len(bytes))
                     else:
                         self.fail("no one on the other side")
                     bytes = bytes + temp


### PR DESCRIPTION
Copied from fract4dgui.gtkfractal.Hidden.onData().

---

This does fix some problems, not convinced it does everything though.

onData seems to just discard messages of the wrong size:

https://github.com/fract4d/gnofract4d/blob/5aaad2ae1d98bada86b0f16d3b3cbaff51150c4c/fract4dgui/gtkfractal.py#L175-L186

I don't know if anyone has any better insight. Else, if the test failures are blocking other work then going back to skipping by reverting a6b74ac16ab7 would probably be best.
