### PR TITLE
Fix --buildonly with an existing directory

### DIFF
--- a/fract4d/fractmain.py
+++ b/fract4d/fractmain.py
@@ -55,8 +55,8 @@ class T:
 
     def buildonly(self, options, outfile):
         outdirname = os.path.dirname(options.buildonly)
-        if len(outdirname) > 0:
-            os.makedirs(outdirname)
+        if outdirname:
+            os.makedirs(outdirname, exist_ok=True)
 
         shutil.copy(outfile, options.buildonly)
         (base, ext) = os.path.splitext(outfile)


### PR DESCRIPTION
exist_ok was introduced in Python 3.2.

Also no need to obtain the length of the directory name.