### PR TITLE
Only draw once on application startup

### DIFF
--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -81,7 +81,7 @@ class MainWindow:
         self.window.add(self.vbox)
 
         self.f = gtkfractal.T(self.compiler, self)
-        self.f.freeze()  # create frozen - main prog will thaw us
+        self.f.freeze()  # create frozen - main prog queues first_draw() to thaw
         self.create_subfracts(self.f)
 
         self.set_filename(None)
@@ -441,6 +441,10 @@ class MainWindow:
             title += "*"
 
         self.window.set_title(title)
+
+    def first_draw(self):
+        self.on_fractal_change()
+        self.f.thaw()
 
     def on_fractal_change(self, *args):
         self.draw()

--- a/gnofract4d
+++ b/gnofract4d
@@ -63,10 +63,9 @@ def gtkmain(userConfig, options):
     mainWindow = main_window.MainWindow(userConfig)
     mainWindow.apply_options(options)
 
-    if mainWindow.f.thaw():
-        gi.require_version('GLib', '2.0')
-        from gi.repository import GLib
-        GLib.idle_add(mainWindow.on_fractal_change)
+    gi.require_version('GLib', '2.0')
+    from gi.repository import GLib
+    GLib.idle_add(mainWindow.first_draw)
 
     Gtk.main()
 


### PR DESCRIPTION
MainWindow.on_fractal_change() was being called several times while the
first fractal was being created.

Prevents application hangs on startup since:
47752e0 ("Hold the GIL while deleting python objects", 2020-08-16)

---

Please check and test, I haven't looked at this code before and got here by experimentation.