### PR TITLE
Prevent GIL deadlock

### DIFF
--- a/fract4d/c/fract4dc/calcargs.cpp
+++ b/fract4d/c/fract4dc/calcargs.cpp
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include <mutex>
 
 #include "calcargs.h"
 
@@ -18,13 +17,10 @@ calc_args::calc_args()
     params = new double[N_PARAMS];
 }
 
-static std::mutex ref_count_mutex;
-
 void calc_args::set_cmap(PyObject *pycmap_)
 {
     pycmap = pycmap_;
     cmap = colormaps::cmap_fromcapsule(pycmap);
-    const std::lock_guard<std::mutex> lock(ref_count_mutex);
     Py_XINCREF(pycmap);
 }
 
@@ -32,7 +28,6 @@ void calc_args::set_pfo(PyObject *pypfo_)
 {
     pypfo = pypfo_;
     pfo = (loaders::pf_fromcapsule(pypfo))->pfo;
-    const std::lock_guard<std::mutex> lock(ref_count_mutex);
     Py_XINCREF(pypfo);
 }
 
@@ -40,14 +35,12 @@ void calc_args::set_im(PyObject *pyim_)
 {
     pyim = pyim_;
     im = images::image_fromcapsule(pyim);
-    const std::lock_guard<std::mutex> lock(ref_count_mutex);
     Py_XINCREF(pyim);
 }
 void calc_args::set_site(PyObject *pysite_)
 {
     pysite = pysite_;
     site = sites::site_fromcapsule(pysite);
-    const std::lock_guard<std::mutex> lock(ref_count_mutex);
     Py_XINCREF(pysite);
 }
 
@@ -57,7 +50,6 @@ calc_args::~calc_args()
 #ifdef DEBUG_CREATION
     fprintf(stderr, "%p : CA : DTOR\n", this);
 #endif
-    const std::lock_guard<std::mutex> lock(ref_count_mutex);
     Py_XDECREF(pycmap);
     Py_XDECREF(pypfo);
     Py_XDECREF(pyim);

--- a/fract4d/c/fract4dmodule.cpp
+++ b/fract4d/c/fract4dmodule.cpp
@@ -651,6 +651,7 @@ PyInit_fract4dc(void)
         return NULL;
     }
 
+    // todo: check this https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads
     PyEval_InitThreads();
 
     /* expose some constants */


### PR DESCRIPTION
See #177 for more details.

> Basically here I'm releasing the interpreter lock immediately instead of waiting for site->wait when fract4dc.calc is called, so the other thread can acquire it.

I've removed the calcargs ref_count mutex as we don't need it since we are doing ref_counting always in the interpreter thread.

Also I created a struct for the GIL acquisition so we can benefit from the RAII pattern.