### PR TITLE
Correct title of Save High-Res Image shortcut

### DIFF
--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -558,11 +558,6 @@ class MainWindow:
                 break
         fs.hide()
 
-    def get_all_actions(self):
-        return self.get_toggle_actions() + \
-            self.get_main_actions() + \
-            self.get_fourd_actions()
-
     def get_toggle_actions(self):
         return [
             ('ToolsExplorerAction', 'explorer_mode', _('Explorer'),

--- a/fract4dgui/shortcuts-gnofract4d.ui
+++ b/fract4dgui/shortcuts-gnofract4d.ui
@@ -188,7 +188,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;I</property>
-                <property name="title" translatable="yes">Add the current fractal to the render queue</property>
+                <property name="title" translatable="yes">Save a higher-resolution version of the current image</property>
               </object>
             </child>
             <child>


### PR DESCRIPTION
I copied the method comment instead of the description for the user from Save High-Res Image.

Also:

Remove unused MainWindow.get_all_actions()

Not used since:
ae9f710 ("Change documentation to markdown (#101)", 2020-06-07)

(fract4dgui/createdocs.py was deleted)

