### PR TITLE
Replace use of deprecated Gtk.UIManager

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -44,7 +44,7 @@ class Benchmark:
     def run_gui(self):
 
         userConfig = fractconfig.userConfig()
-        window = main_window.MainWindow(userConfig)
+        window = main_window.MainWindow(Gtk.Application(), userConfig)
 
         window.f.set_size(self.w, self.h)
         window.f.thaw()

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -608,7 +608,7 @@ class MainWindow:
             ("ToolsPainterAction", self.painter),
 
             ("HelpContentsAction", self.contents),
-            ("HelpCommandReferenceAction", self.command_reference),
+            # Command Reference action is win.show-help-overlay
             ("HelpReportBugAction", self.report_bug),
             ("HelpAboutAction", self.about),
 
@@ -660,11 +660,7 @@ class MainWindow:
         # command reference
         builder = Gtk.Builder.new_from_file(
             os.path.join(this_path, "shortcuts-gnofract4d.ui"))
-        self.shortcuts_window = builder.get_object("shortcuts-gnofract4d")
-        self.shortcuts_window.set_transient_for(self.window)
-        self.shortcuts_window.connect(
-            "delete-event",
-            lambda widget, event: Gtk.Window.hide_on_delete(widget))
+        self.window.set_help_overlay(builder.get_object("shortcuts-gnofract4d"))
 
     def director(self, *args):
         """Display the Director (animation) window."""
@@ -1229,9 +1225,6 @@ class MainWindow:
     def contents(self, *args):
         """Show help file contents page."""
         self.display_help()
-
-    def command_reference(self, *args):
-        self.shortcuts_window.show_all()
 
     def report_bug(self, *args):
         url = "https://github.com/fract4d/gnofract4d/issues"

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -653,10 +653,9 @@ class MainWindow:
 
         self.application.set_menubar(builder.get_object("menubar"))
 
-        undo = self.application.lookup_action("EditUndoAction")
-        self.model.seq.make_undo_sensitive(undo)
-        redo = self.application.lookup_action("EditRedoAction")
-        self.model.seq.make_redo_sensitive(redo)
+        self.model.seq.register_callbacks(
+            self.application.lookup_action("EditRedoAction").set_enabled,
+            self.application.lookup_action("EditUndoAction").set_enabled)
 
         # command reference
         builder = Gtk.Builder.new_from_file(

--- a/fract4dgui/shortcuts-gnofract4d.ui
+++ b/fract4dgui/shortcuts-gnofract4d.ui
@@ -10,40 +10,47 @@
         <child>
           <object class="GtkShortcutsGroup">
             <property name="title" translatable="yes">Mouse Commands</property>
+            <property name="visible">1</property>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">Pointer_Button1</property>
                 <property name="title" translatable="yes">Zoom in</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">Pointer_Drag1</property>
                 <property name="title" translatable="yes">Draw rectangle to zoom into</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;shift&gt;Pointer_Button1</property>
                 <property name="title" translatable="yes">Recenter image on point clicked</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">Pointer_Button3</property>
                 <property name="title" translatable="yes">Flip to Julia set (or back to Mandelbrot)</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">Pointer_Button2</property>
                 <property name="title" translatable="yes">Zoom out</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;Pointer_Button2</property>
                 <property name="title" translatable="yes">Zoom out more quickly</property>
+                <property name="visible">1</property>
               </object>
             </child>
           </object>
@@ -51,168 +58,197 @@
         <child>
           <object class="GtkShortcutsGroup">
             <property name="title" translatable="yes">Keyboard Shortcuts</property>
-              <child>
+            <property name="visible">1</property>
+            <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">cursor</property>
                 <property name="title" translatable="yes">Pan image in indicated direction</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;cursor</property>
                 <property name="title" translatable="yes">Pan more quickly in indicated direction</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;shift&gt;cursor</property>
                 <property name="title" translatable="yes">Mutate image in Z or W directions</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;shift&gt;&lt;ctrl&gt;cursor</property>
                 <property name="title" translatable="yes">Mutate more quickly</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;KP_1</property>
                 <property name="title" translatable="yes">Reset rotation to show the XY (Mandelbrot) plane</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;KP_2</property>
                 <property name="title" translatable="yes">Reset rotation to show the ZW (Julia) plane</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;KP_3</property>
                 <property name="title" translatable="yes">Reset rotation to show the XZ (Oblate) plane</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;KP_4</property>
                 <property name="title" translatable="yes">Reset rotation to show the XW (Parabolic) plane</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;KP_5</property>
                 <property name="title" translatable="yes">Reset rotation to show the YZ (Elliptic) plane</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;KP_6</property>
                 <property name="title" translatable="yes">Reset rotation to show the WY (Rectangular) plane</property>
+                <property name="visible">1</property>
               </object>
             </child>
           </object>
         </child>
         <child>
           <object class="GtkShortcutsGroup">
+            <property name="visible">1</property>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;A</property>
                 <property name="title" translatable="yes">Display AutoZoom dialog</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;B</property>
                 <property name="title" translatable="yes">Display formula browser</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;D</property>
                 <property name="title" translatable="yes">Display the Director (animation) window</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;E</property>
                 <property name="title" translatable="yes">Enter (or leave) Explorer mode</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;F</property>
                 <property name="title" translatable="yes">Show fractal settings controls</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">F11</property>
                 <property name="title" translatable="yes">Show main window full-screen</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">Escape</property>
                 <property name="title" translatable="yes">Quit full-screen mode</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">F1</property>
                 <property name="title" translatable="yes">Show help file contents page</property>
+                <property name="visible">1</property>
               </object>
             </child>
-          </object>  
+          </object>
         </child>
         <child>
           <object class="GtkShortcutsGroup">
+            <property name="visible">1</property>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">Home</property>
                 <property name="title" translatable="yes">Reset all numeric parameters to their defaults</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;Home</property>
                 <property name="title" translatable="yes">Reset zoom to default level</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;I</property>
                 <property name="title" translatable="yes">Save the current image to a file</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;I</property>
                 <property name="title" translatable="yes">Save a higher-resolution version of the current image</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;R</property>
                 <property name="title" translatable="yes">Create a new random color scheme</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;S</property>
                 <property name="title" translatable="yes">Save the current parameters into a new file</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;Z</property>
                 <property name="title" translatable="yes">Undo the last operation</property>
+                <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;Z</property>
                 <property name="title" translatable="yes">Redo an operation after undoing it</property>
+                <property name="visible">1</property>
               </object>
             </child>
           </object>

--- a/fract4dgui/shortcuts-gnofract4d.ui
+++ b/fract4dgui/shortcuts-gnofract4d.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.17 -->
+  <!-- interface-requires gtk+ 3.22 -->
   <object class="GtkShortcutsWindow" id="shortcuts-gnofract4d">
     <property name="modal">1</property>
     <child>
@@ -89,42 +89,42 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;KP_1</property>
+                <property name="action-name">app.PlanesXYAction</property>
                 <property name="title" translatable="yes">Reset rotation to show the XY (Mandelbrot) plane</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;KP_2</property>
+                <property name="action-name">app.PlanesZWAction</property>
                 <property name="title" translatable="yes">Reset rotation to show the ZW (Julia) plane</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;KP_3</property>
+                <property name="action-name">app.PlanesXZAction</property>
                 <property name="title" translatable="yes">Reset rotation to show the XZ (Oblate) plane</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;KP_4</property>
+                <property name="action-name">app.PlanesXWAction</property>
                 <property name="title" translatable="yes">Reset rotation to show the XW (Parabolic) plane</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;KP_5</property>
+                <property name="action-name">app.PlanesYZAction</property>
                 <property name="title" translatable="yes">Reset rotation to show the YZ (Elliptic) plane</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;KP_6</property>
+                <property name="action-name">app.PlanesWYAction</property>
                 <property name="title" translatable="yes">Reset rotation to show the WY (Rectangular) plane</property>
                 <property name="visible">1</property>
               </object>
@@ -136,42 +136,42 @@
             <property name="visible">1</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;A</property>
+                <property name="action-name">app.ToolsAutozoomAction</property>
                 <property name="title" translatable="yes">Display AutoZoom dialog</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;B</property>
+                <property name="action-name">app.ToolsBrowserAction</property>
                 <property name="title" translatable="yes">Display formula browser</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;D</property>
+                <property name="action-name">app.ToolsDirectorAction</property>
                 <property name="title" translatable="yes">Display the Director (animation) window</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;E</property>
+                <property name="action-name">app.ToolsExplorerAction</property>
                 <property name="title" translatable="yes">Enter (or leave) Explorer mode</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;F</property>
+                <property name="action-name">app.EditFractalSettingsAction</property>
                 <property name="title" translatable="yes">Show fractal settings controls</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">F11</property>
+                <property name="action-name">app.ViewFullScreenAction</property>
                 <property name="title" translatable="yes">Show main window full-screen</property>
                 <property name="visible">1</property>
               </object>
@@ -185,7 +185,7 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">F1</property>
+                <property name="action-name">app.HelpContentsAction</property>
                 <property name="title" translatable="yes">Show help file contents page</property>
                 <property name="visible">1</property>
               </object>
@@ -197,56 +197,56 @@
             <property name="visible">1</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">Home</property>
+                <property name="action-name">app.EditResetAction</property>
                 <property name="title" translatable="yes">Reset all numeric parameters to their defaults</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;Home</property>
+                <property name="action-name">app.EditResetZoomAction</property>
                 <property name="title" translatable="yes">Reset zoom to default level</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;I</property>
+                <property name="action-name">app.FileSaveImageAction</property>
                 <property name="title" translatable="yes">Save the current image to a file</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;I</property>
+                <property name="action-name">app.FileSaveHighResImageAction</property>
                 <property name="title" translatable="yes">Save a higher-resolution version of the current image</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;R</property>
+                <property name="action-name">app.ToolsRandomizeAction</property>
                 <property name="title" translatable="yes">Create a new random color scheme</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;S</property>
+                <property name="action-name">app.FileSaveAsAction</property>
                 <property name="title" translatable="yes">Save the current parameters into a new file</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;Z</property>
+                <property name="action-name">app.EditUndoAction</property>
                 <property name="title" translatable="yes">Undo the last operation</property>
                 <property name="visible">1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;Z</property>
+                <property name="action-name">app.EditRedoAction</property>
                 <property name="title" translatable="yes">Redo an operation after undoing it</property>
                 <property name="visible">1</property>
               </object>

--- a/fract4dgui/tests/test_main_window.py
+++ b/fract4dgui/tests/test_main_window.py
@@ -18,7 +18,7 @@ class WrapMainWindow(main_window.MainWindow):
     @patch('fract4d.fractconfig.T.get_data_path')
     def __init__(self, config, extra_paths=[]):
         self.errors = []
-        main_window.MainWindow.__init__(self, config, ['formulas'])
+        main_window.MainWindow.__init__(self, Gtk.Application(), config, ['formulas'])
 
     def show_error_message(self, message, exception):
         self.errors.append((message, exception))
@@ -30,11 +30,11 @@ class Test(testgui.TestCase):
         self.assertEqual(self.mw.filename, None, "shouldn't have a filename")
 
     def wait(self):
-        Gtk.main()
+        self.mw.application.run()
 
     def quitloop(self, f, status):
         if status == 0:
-            Gtk.main_quit()
+            self.mw.application.quit()
 
     def testLoad(self):
         # load good file

--- a/fract4dgui/tests/test_main_window.py
+++ b/fract4dgui/tests/test_main_window.py
@@ -177,3 +177,9 @@ class Test(testgui.TestCase):
             self.assertRaises(IOError, WrapMainWindow, Test.userConfig)
         finally:
             fractal.T.DEFAULT_FORMULA_FILE = old_default
+
+
+class TestApplication(testgui.TestCase):
+    def testApplication(self):
+        app = main_window.Application(None, Test.userConfig)
+        self.assertEqual(app.userConfig, Test.userConfig)

--- a/fract4dgui/tests/test_model.py
+++ b/fract4dgui/tests/test_model.py
@@ -26,6 +26,7 @@ class Test(testgui.TestCase):
         Test.g_comp.load_formula_file("gf4d.cfrm")
         self.f = gtkfractal.T(Test.g_comp)
         self.m = model.Model(self.f)
+        self.m.seq.register_callbacks(lambda x: x, lambda x: x)
 
     def tearDown(self):
         self.f = self.m = None

--- a/fract4dgui/toolbar.py
+++ b/fract4dgui/toolbar.py
@@ -23,17 +23,17 @@ class T(Gtk.Toolbar):
         toolitem.set_tooltip_text(tip_text)
         self.insert(toolitem, -1)
 
-    def add_button(self, icon_name, tip_text, cb):
+    def add_button(self, icon_name, tip_text, action):
         toolitem = Gtk.ToolButton.new()
         toolitem.set_icon_name(icon_name)
-        toolitem.connect('clicked', cb)
+        toolitem.set_action_name(action)
         toolitem.set_tooltip_text(tip_text)
         self.insert(toolitem, -1)
 
-    def add_toggle(self, icon_name, tip_text, cb):
+    def add_toggle(self, icon_name, tip_text, action):
         toolitem = Gtk.ToggleToolButton.new()
         toolitem.set_icon_name(icon_name)
-        toolitem.connect('toggled', cb)
+        toolitem.set_action_name(action)
         toolitem.set_tooltip_text(tip_text)
         self.insert(toolitem, -1)
         return toolitem

--- a/fract4dgui/ui.xml
+++ b/fract4dgui/ui.xml
@@ -1,49 +1,177 @@
-<ui>
-  <menubar name="MenuBar">
-    <menu name="FileMenu" action = "FileMenuAction">
-       <menuitem name="OpenFile" action="FileOpenAction"/>
-       <menuitem name="Save" action="FileSaveAction"/>
-       <menuitem name="SaveAs" action="FileSaveAsAction"/>
-       <menuitem name="SaveImage" action="FileSaveImageAction"/>
-       <menuitem name="SaveHiResImage" action="FileSaveHighResImageAction"/>
-       <separator/>
-       <menuitem name="Quit" action="FileQuitAction"/>
-    </menu>
-    <menu name="EditMenu" action="EditMenuAction">
-      <menuitem name="EditSettings" action="EditFractalSettingsAction"/>
-      <menuitem name="EditPreferences" action="EditPreferencesAction"/>
-      <separator/>
-      <menuitem name="EditUndo" action="EditUndoAction"/>
-      <menuitem name="EditRedo" action="EditRedoAction"/>
-      <separator/>
-      <menuitem name="EditReset" action="EditResetAction"/>
-      <menuitem name="EditResetZoom" action="EditResetZoomAction"/>   
-      <menuitem name="EditPaste" action="EditPasteAction"/>   
-    </menu>
-    <menu name="ViewMenu" action="ViewMenuAction">
-      <menuitem name="ViewFullScreen" action="ViewFullScreenAction"/>
-      <menu name="PlanesMenu" action="PlanesMenuAction">
-	<menuitem name="PlanesXY" action="PlanesXYAction"/>
-	<menuitem name="PlanesZW" action="PlanesZWAction"/>
-	<menuitem name="PlanesXZ" action="PlanesXZAction"/>
-	<menuitem name="PlanesXW" action="PlanesXWAction"/>
-	<menuitem name="PlanesYZ" action="PlanesYZAction"/>
-	<menuitem name="PlanesWY" action="PlanesWYAction"/>
-      </menu>
-    </menu>
-    <menu name="ToolsMenu" action="ToolsMenuAction">
-      <menuitem name="ToolsAutozoom" action="ToolsAutozoomAction"/>
-      <menuitem name="ToolsExplorer" action="ToolsExplorerAction"/>
-      <menuitem name="ToolsBrowser" action="ToolsBrowserAction"/>
-      <menuitem name="ToolsDirector" action="ToolsDirectorAction"/>
-      <menuitem name="ToolsRandomize" action="ToolsRandomizeAction"/>
-      <menuitem name="ToolsPainter" action="ToolsPainterAction"/>
-    </menu>
-    <menu name="HelpMenu" action="HelpMenuAction">
-      <menuitem name="HelpContents" action="HelpContentsAction"/>
-      <menuitem name="HelpCommandRef" action="HelpCommandReferenceAction"/>
-      <menuitem name="HelpReportBug" action="HelpReportBugAction"/>
-      <menuitem name="HelpAbout" action="HelpAboutAction"/>
-    </menu>
-  </menubar>
-</ui>
+<interface>
+  <menu id="menubar">
+    <submenu>
+      <attribute name="label" translatable="yes">_File</attribute>
+      <section>
+        <item>
+          <attribute name="action">app.FileOpenAction</attribute>
+          <attribute name="label" translatable="yes">_Open...</attribute>
+          <attribute name="accel">&lt;control&gt;O</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.FileSaveAction</attribute>
+          <attribute name="label" translatable="yes">_Save</attribute>
+          <attribute name="accel">&lt;control&gt;S</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.FileSaveAsAction</attribute>
+          <attribute name="label" translatable="yes">Save _As...</attribute>
+          <attribute name="accel">&lt;control&gt;&lt;shift&gt;S</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.FileSaveImageAction</attribute>
+          <attribute name="label" translatable="yes">Save Current _Image</attribute>
+          <attribute name="accel">&lt;control&gt;I</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.FileSaveHighResImageAction</attribute>
+          <attribute name="label" translatable="yes">Save _High-Res Image...</attribute>
+          <attribute name="accel">&lt;control&gt;&lt;shift&gt;I</attribute>
+        </item>
+      </section>
+      <section>
+        <item>
+          <attribute name="action">app.FileQuitAction</attribute>
+          <attribute name="label" translatable="yes">_Quit</attribute>
+          <attribute name="accel">&lt;control&gt;Q</attribute>
+        </item>
+      </section>
+    </submenu>
+    <submenu>
+      <attribute name="label" translatable="yes">_Edit</attribute>
+      <section>
+        <item>
+          <attribute name="action">app.EditFractalSettingsAction</attribute>
+          <attribute name="label" translatable="yes">_Fractal Settings...</attribute>
+          <attribute name="accel">&lt;control&gt;F</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.EditPreferencesAction</attribute>
+          <attribute name="label" translatable="yes">_Preferences</attribute>
+        </item>
+      </section>
+      <section>
+        <item>
+          <attribute name="action">app.EditUndoAction</attribute>
+          <attribute name="label" translatable="yes">_Undo</attribute>
+          <attribute name="accel">&lt;control&gt;Z</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.EditRedoAction</attribute>
+          <attribute name="label" translatable="yes">_Redo</attribute>
+          <attribute name="accel">&lt;control&gt;&lt;shift&gt;Z</attribute>
+        </item>
+      </section>
+      <section>
+        <item>
+          <attribute name="action">app.EditResetAction</attribute>
+          <attribute name="label" translatable="yes">_Reset</attribute>
+          <attribute name="accel">Home</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.EditResetZoomAction</attribute>
+          <attribute name="label" translatable="yes">Re_set Zoom</attribute>
+          <attribute name="accel">&lt;control&gt;Home</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.EditPasteAction</attribute>
+          <attribute name="label" translatable="yes">Paste Gradient</attribute>
+          <attribute name="accel">&lt;control&gt;V</attribute>
+        </item>
+      </section>
+    </submenu>
+    <submenu>
+      <attribute name="label" translatable="yes">_View</attribute>
+      <item>
+        <attribute name="action">app.ViewFullScreenAction</attribute>
+        <attribute name="label" translatable="yes">_Full Screen</attribute>
+        <attribute name="accel">F11</attribute>
+      </item>
+      <submenu>
+        <attribute name="label" translatable="yes">Planes</attribute>
+        <item>
+          <attribute name="action">app.PlanesXYAction</attribute>
+          <attribute name="label" translatable="yes">_XY (Mandelbrot)</attribute>
+          <attribute name="accel">&lt;control&gt;1</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.PlanesZWAction</attribute>
+          <attribute name="label" translatable="yes">_ZW (Julia)</attribute>
+          <attribute name="accel">&lt;control&gt;2</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.PlanesXZAction</attribute>
+          <attribute name="label" translatable="yes">_XZ (Oblate)</attribute>
+          <attribute name="accel">&lt;control&gt;3</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.PlanesXWAction</attribute>
+          <attribute name="label" translatable="yes">_XW (Parabolic)</attribute>
+          <attribute name="accel">&lt;control&gt;4</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.PlanesYZAction</attribute>
+          <attribute name="label" translatable="yes">_ZY (Elliptic)</attribute>
+          <attribute name="accel">&lt;control&gt;5</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.PlanesWYAction</attribute>
+          <attribute name="label" translatable="yes">_WY (Rectangular)</attribute>
+          <attribute name="accel">&lt;control&gt;6</attribute>
+        </item>
+      </submenu>
+    </submenu>
+    <submenu>
+      <attribute name="label" translatable="yes">_Tools</attribute>
+      <item>
+        <attribute name="action">app.ToolsAutozoomAction</attribute>
+        <attribute name="label" translatable="yes">_Autozoom</attribute>
+        <attribute name="accel">&lt;control&gt;A</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.ToolsExplorerAction</attribute>
+        <attribute name="label" translatable="yes">Explorer</attribute>
+        <attribute name="accel">&lt;control&gt;E</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.ToolsBrowserAction</attribute>
+        <attribute name="label" translatable="yes">Formula _Browser</attribute>
+        <attribute name="accel">&lt;control&gt;B</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.ToolsDirectorAction</attribute>
+        <attribute name="label" translatable="yes">_Director</attribute>
+        <attribute name="accel">&lt;control&gt;D</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.ToolsRandomizeAction</attribute>
+        <attribute name="label" translatable="yes">_Randomize Colors</attribute>
+        <attribute name="accel">&lt;control&gt;R</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.ToolsPainterAction</attribute>
+        <attribute name="label" translatable="yes">_Painter</attribute>
+      </item>
+    </submenu>
+    <submenu>
+      <attribute name="label" translatable="yes">_Help</attribute>
+      <item>
+        <attribute name="action">app.HelpContentsAction</attribute>
+        <attribute name="label" translatable="yes">_Contents</attribute>
+        <attribute name="accel">F1</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.HelpCommandReferenceAction</attribute>
+        <attribute name="label" translatable="yes">Command _Reference</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.HelpReportBugAction</attribute>
+        <attribute name="label" translatable="yes">_Report a Bug</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.HelpAboutAction</attribute>
+        <attribute name="label" translatable="yes">_About</attribute>
+      </item>
+    </submenu>
+  </menu>
+</interface>

--- a/fract4dgui/ui.xml
+++ b/fract4dgui/ui.xml
@@ -161,7 +161,7 @@
         <attribute name="accel">F1</attribute>
       </item>
       <item>
-        <attribute name="action">app.HelpCommandReferenceAction</attribute>
+        <attribute name="action">win.show-help-overlay</attribute>
         <attribute name="label" translatable="yes">Command _Reference</attribute>
       </item>
       <item>

--- a/fract4dgui/undo.py
+++ b/fract4dgui/undo.py
@@ -67,22 +67,22 @@ class Sequence(GObject.GObject):
 
         self.send_signals()
 
-    def make_undo_sensitive(self, widget):
-        # make this widget only be sensitive if we can undo
+    def make_undo_sensitive(self, action):
+        # enable this action only if we can undo
 
-        def set_sensitivity(sequence, can_undo):
-            widget.set_sensitive(can_undo)
+        def set_enabled(sequence, can_undo):
+            action.set_enabled(can_undo)
 
-        self.connect('can-undo', set_sensitivity)
+        self.connect('can-undo', set_enabled)
         self.emit('can-undo', self.can_undo())
 
-    def make_redo_sensitive(self, widget):
-        # make this widget only be sensitive if we can undo
+    def make_redo_sensitive(self, action):
+        # enable this action only if we can redo
 
-        def set_sensitivity(sequence, can_redo):
-            widget.set_sensitive(can_redo)
+        def set_enabled(sequence, can_redo):
+            action.set_enabled(can_redo)
 
-        self.connect('can-redo', set_sensitivity)
+        self.connect('can-redo', set_enabled)
         self.emit('can-redo', self.can_redo())
 
 

--- a/fract4dgui/undo.py
+++ b/fract4dgui/undo.py
@@ -1,7 +1,4 @@
 
-from gi.repository import GObject
-
-
 class HistoryEntry:
     def __init__(self, redo, redo_data, undo, undo_data):
         self.undo_action = undo
@@ -16,18 +13,17 @@ class HistoryEntry:
         self.redo_action(self.redo_data)
 
 
-class Sequence(GObject.GObject):
-    __gsignals__ = {
-        'can-undo': (
-            GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_BOOLEAN,)),
-        'can-redo': (
-            GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_BOOLEAN,))
-    }
-
+class Sequence:
     def __init__(self):
-        GObject.GObject.__init__(self)
         self.pos = 0  # the position after the current item
         self.history = []
+        self.redo_callback = None
+        self.undo_callback = None
+
+    def register_callbacks(self, redo_callback, undo_callback):
+        self.redo_callback = redo_callback
+        self.undo_callback = undo_callback
+        self.execute_callbacks()
 
     def can_undo(self):
         return self.pos > 0
@@ -35,9 +31,9 @@ class Sequence(GObject.GObject):
     def can_redo(self):
         return self.pos < len(self.history)
 
-    def send_signals(self):
-        self.emit('can-undo', self.can_undo())
-        self.emit('can-redo', self.can_redo())
+    def execute_callbacks(self):
+        self.redo_callback(self.can_redo())
+        self.undo_callback(self.can_undo())
 
     def do(self, redo_action, redo_data, undo_action, undo_data):
         # replace everything from here on with the new item
@@ -50,14 +46,15 @@ class Sequence(GObject.GObject):
             HistoryEntry(redo_action, redo_data, undo_action, undo_data))
         self.pos = len(self.history)
 
-        self.send_signals()
+        self.execute_callbacks()
 
     def undo(self):
         if not self.can_undo():
             raise ValueError("Can't Undo at start of sequence")
         self.pos -= 1
         self.history[self.pos].undo()
-        self.send_signals()
+
+        self.execute_callbacks()
 
     def redo(self):
         if not self.can_redo():
@@ -65,25 +62,4 @@ class Sequence(GObject.GObject):
         self.history[self.pos].redo()
         self.pos += 1
 
-        self.send_signals()
-
-    def make_undo_sensitive(self, action):
-        # enable this action only if we can undo
-
-        def set_enabled(sequence, can_undo):
-            action.set_enabled(can_undo)
-
-        self.connect('can-undo', set_enabled)
-        self.emit('can-undo', self.can_undo())
-
-    def make_redo_sensitive(self, action):
-        # enable this action only if we can redo
-
-        def set_enabled(sequence, can_redo):
-            action.set_enabled(can_redo)
-
-        self.connect('can-redo', set_enabled)
-        self.emit('can-redo', self.can_redo())
-
-
-GObject.type_register(Sequence)
+        self.execute_callbacks()

--- a/gnofract4d
+++ b/gnofract4d
@@ -43,15 +43,6 @@ def main(args):
         raise
 
 def gtkmain(userConfig, options):
-    # GTK+
-    import gi
-    gi.require_version('Gtk', '3.0')
-    try:
-        from gi.repository import Gtk
-    except ImportError as err:
-        print(_("Can't find Gtk. You need to install it before you can run Gnofract 4D."))
-        sys.exit(1)
-
     try:
         # GUI module
         from fract4dgui import main_window
@@ -60,14 +51,8 @@ def gtkmain(userConfig, options):
         print(_("Error was: '%s'") % err)
         sys.exit(1)
 
-    mainWindow = main_window.MainWindow(userConfig)
-    mainWindow.apply_options(options)
-
-    gi.require_version('GLib', '2.0')
-    from gi.repository import GLib
-    GLib.idle_add(mainWindow.first_draw)
-
-    Gtk.main()
+    app = main_window.Application(options, userConfig)
+    app.run()
 
 def plainmain(userConfig, options):
     t = fractmain.T(userConfig)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore:Gtk.ActionGroup.*:DeprecationWarning
-    ignore:Gtk.ToggleAction.[sg]et_active.*:DeprecationWarning
-    ignore:Gtk.UIManager.*:DeprecationWarning


### PR DESCRIPTION
WIP because it includes a couple of other PRs and so would be rebased and even changed if we stick at GTK 3.18.

One new feature which is enforcing uniqueness i.e. only one copy of Gnofract 4D can run at a time (is there a case for running more than one?).

Mainly fixing GTK deprecation warnings with an eye on GTK 4. Replacing Gtk.UIManager, including translating the menu XMLs into GMenuModel representations that will be the only format for the future.

Closes #44.