### PR TITLE
Set defaults in FileChooserDialogs and replace stock labels

### DIFF
--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -109,8 +109,8 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
         dialog = Gtk.FileChooserDialog(title="Choose keyframe...",
                                        transient_for=self,
                                        action=Gtk.FileChooserAction.OPEN)
-        dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                           Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        dialog.add_buttons(_("_Cancel"), Gtk.ResponseType.CANCEL,
+                           _("_Open"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
         # ----setting filters---------
         filter = Gtk.FileFilter()
@@ -135,8 +135,8 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
         dialog = Gtk.FileChooserDialog(title="Save AVI file...",
                                        transient_for=self,
                                        action=Gtk.FileChooserAction.SAVE)
-        dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                           Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        dialog.add_buttons(_("_Cancel"), Gtk.ResponseType.CANCEL,
+                           _("_OK"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
         current_file = self.txt_temp_avi.get_text()
         dialog.set_current_name(current_file if current_file else "video.webm")
@@ -163,8 +163,8 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
         dialog = Gtk.FileChooserDialog(title="Save animation...",
                                        transient_for=self,
                                        action=Gtk.FileChooserAction.SAVE)
-        dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                           Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        dialog.add_buttons(_("_Cancel"), Gtk.ResponseType.CANCEL,
+                           _("Save"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
         dialog.set_current_name("animation.fcta")
         # ----setting filters---------
@@ -190,8 +190,8 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
         dialog = Gtk.FileChooserDialog(title="Choose animation...",
                                        transient_for=self,
                                        action=Gtk.FileChooserAction.OPEN)
-        dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                           Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        dialog.add_buttons(_("_Cancel"), Gtk.ResponseType.CANCEL,
+                           _("_Open"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
         # ----setting filters---------
         filter = Gtk.FileFilter()

--- a/fract4dgui/director_prefs.py
+++ b/fract4dgui/director_prefs.py
@@ -13,8 +13,8 @@ class DirectorPrefs:
         dialog = Gtk.FileChooserDialog(title="Choose directory...",
                                        transient_for=self.dialog,
                                        action=Gtk.FileChooserAction.SELECT_FOLDER)
-        dialog.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                           Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        dialog.add_buttons(_("_Cancel"), Gtk.ResponseType.CANCEL,
+                           _("_OK"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
         response = dialog.run()
         if response == Gtk.ResponseType.OK:

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -167,8 +167,9 @@ class MainWindow:
             action=Gtk.FileChooserAction.SAVE)
 
         chooser.add_buttons(
-            Gtk.STOCK_OK, Gtk.ResponseType.OK,
-            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+            _("_Save"), Gtk.ResponseType.OK,
+            _("_Cancel"), Gtk.ResponseType.CANCEL)
+        chooser.set_default_response(Gtk.ResponseType.OK)
 
         filter = Gtk.FileFilter()
         for pattern in patterns:
@@ -247,8 +248,9 @@ class MainWindow:
             action=Gtk.FileChooserAction.OPEN)
 
         self.open_fs.add_buttons(
-            Gtk.STOCK_OK, Gtk.ResponseType.OK,
-            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+            _("_Open"), Gtk.ResponseType.OK,
+            _("_Cancel"), Gtk.ResponseType.CANCEL)
+        self.open_fs.set_default_response(Gtk.ResponseType.OK)
 
         self.add_filters(self.open_fs)
 

--- a/fract4dgui/tests/test_director.py
+++ b/fract4dgui/tests/test_director.py
@@ -2,6 +2,7 @@
 
 # unit tests for renderqueue module
 
+from unittest.mock import patch
 import os.path
 
 from . import testgui
@@ -61,6 +62,28 @@ class Test(testgui.TestCase):
             self.assertEqual(True, os.path.exists(video_file))
 
         dd.destroy()
+
+    @patch("gi.repository.Gtk.FileChooserDialog.run")
+    @patch("gi.repository.Gtk.FileChooserDialog.get_filename")
+    def testFileChoosers(self, mock_dialog_get_filename, mock_dialog_run):
+        filename = "test_file"
+        mock_dialog_get_filename.side_effect = lambda : filename
+
+        f = fractal.T(Test.g_comp)
+        parent = Gtk.Window()
+        dd = director.DirectorDialog(parent, f, Test.userConfig)
+
+        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.OK
+        self.assertEqual(dd.get_fct_file(), filename)
+        self.assertEqual(dd.get_avi_file(), filename)
+        self.assertEqual(dd.get_cfg_file_save(), filename)
+        self.assertEqual(dd.get_cfg_file_open(), filename)
+
+        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.CANCEL
+        self.assertEqual(dd.get_fct_file(), "")
+        self.assertEqual(dd.get_avi_file(), "")
+        self.assertEqual(dd.get_cfg_file_save(), "")
+        self.assertEqual(dd.get_cfg_file_open(), "")
 
     def assertRaisesMessage(self, excClass, msg, callable, *args, **kwargs):
         try:

--- a/fract4dgui/tests/test_director_prefs.py
+++ b/fract4dgui/tests/test_director_prefs.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# unit tests for director_prefs module
+
+from unittest.mock import patch
+
+from . import testgui
+
+from gi.repository import Gtk
+
+from fract4dgui import director_prefs
+from fract4d import fractal, animation
+
+
+class Test(testgui.TestCase):
+    def setUp(self):
+        f = fractal.T(Test.g_comp)
+        self.test_animation = animation.T(f.compiler, Test.userConfig)
+
+    def testDirectorPrefsDialog(self):
+        parent = Gtk.Window()
+        dp = director_prefs.DirectorPrefs(self.test_animation, parent)
+
+        self.assertEqual(dp.chk_create_fct.get_label(), "Create temporary .fct files")
+
+    @patch("gi.repository.Gtk.FileChooserDialog.run")
+    @patch("gi.repository.Gtk.FileChooserDialog.get_filename")
+    def testGetFolder(self, mock_dialog_get_filename, mock_dialog_run):
+        filename = "test_file"
+        mock_dialog_get_filename.side_effect = lambda : filename
+
+        parent = Gtk.Window()
+        dp = director_prefs.DirectorPrefs(self.test_animation, parent)
+
+        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.OK
+        self.assertEqual(dp.get_folder(), filename)
+
+        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.CANCEL
+        self.assertEqual(dp.get_folder(), "")

--- a/fract4dgui/utils.py
+++ b/fract4dgui/utils.py
@@ -83,8 +83,9 @@ def get_directory_chooser(title, parent):
         action=Gtk.FileChooserAction.SELECT_FOLDER)
 
     chooser.add_buttons(
-        Gtk.STOCK_OK, Gtk.ResponseType.OK,
-        Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        _("_OK"), Gtk.ResponseType.OK,
+        _("_Cancel"), Gtk.ResponseType.CANCEL)
+    chooser.set_default_response(Gtk.ResponseType.OK)
 
     return chooser
 

--- a/fract4dgui/utils.py
+++ b/fract4dgui/utils.py
@@ -90,10 +90,6 @@ def get_directory_chooser(title, parent):
     return chooser
 
 
-def get_file_chooser_extra_widget(chooser):
-    return chooser.get_extra_widget()
-
-
 def set_file_chooser_filename(chooser, name):
     if name:
         chooser.set_current_folder(os.path.abspath(os.path.dirname(name)))


### PR DESCRIPTION
Use "Save" and "Open" labels instead of "OK".

Stock labels are deprecated.

---

Also remove unused utils.get_file_chooser_extra_widget()