### PR TITLE
Configure Codecov to wait for all results and set threshold

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  notify:
+    # Ensure both Mac and Linux results are uploaded
+    after_n_builds: 4
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.05%


### PR DESCRIPTION
Coverage requires Mac and Linux testing.

Don't fail check for small decreases in coverage.