### PR TITLE
Fix duplicating formula_paths in user configuration

### DIFF
--- a/fract4d/tests/test_fractconfig.py
+++ b/fract4d/tests/test_fractconfig.py
@@ -73,3 +73,11 @@ class Test(testbase.TestSetup):
     def testDarwin(self):
         c = fractconfig.DarwinConfig("testprefs")
         self.assertEqual("open -e", c.get_default_editor())
+
+    def testUpdatePaths(self):
+        self.userConfig["formula_path"] = {
+            "0": "formulas", "1": "/usr/share/gnofract4d", "2":"/home/fract4d/formulas"}
+        self.userConfig.update_paths("formula_path")
+        self.assertEqual(
+            self.userConfig["formula_path"],
+            {"formulas": None, "/usr/share/gnofract4d": None, "/home/fract4d/formulas": None})

--- a/fract4d/tests/testbase.py
+++ b/fract4d/tests/testbase.py
@@ -255,8 +255,8 @@ class ClassSetup(TestBase):
         cls.userConfig.set("general", "cache_dir",
                            os.path.join(cls.tmpdir.name, "gnofract4d-cache"))
 
-        cls.userConfig["formula_path"] = {"0": "formulas",
-                                          "1": "testdata/formulas"}
+        cls.userConfig["formula_path"] = {"formulas": None,
+                                          "testdata/formulas": None}
         cls.g_comp = fc.Compiler(cls.userConfig)
 
     @classmethod
@@ -277,7 +277,7 @@ class TestSetup(TestBase):
 
         self.userConfig.set("general", "cache_dir",
                             os.path.join(self.tmpdir.name, "gnofract4d-cache"))
-        self.userConfig["formula_path"] = {"0": "formulas"}
+        self.userConfig["formula_path"] = {"formulas": None}
         self.g_comp = fc.Compiler(self.userConfig)
 
     def tearDown(self):


### PR DESCRIPTION
If the user removes _shared_formula_dir, on the next start-up
a second ${HOME}/gnofract4d/formulas was also being added.

Fixed by removing the numeric keys from the path items - order is
preserved by the dictionary containing them.

---

Split out because it changes the config file format - but includes code to automatically convert older files to make it transparent.

This one is draft because it is based on #213.
