### PR TITLE
Replace Gtk.Toolbar, deprecated for GTK 4

### DIFF
--- a/fract4dgui/angle.py
+++ b/fract4dgui/angle.py
@@ -20,7 +20,7 @@ class T(Gtk.DrawingArea):
     two_pi = 2.0 * math.pi
     ptr_radius = 4
 
-    def __init__(self, text):
+    def __init__(self, text, tip):
         self.radius = 0
         self.text = text
 
@@ -36,7 +36,7 @@ class T(Gtk.DrawingArea):
 
         self.adjustment.connect('value-changed', self.onAdjustmentValueChanged)
 
-        Gtk.DrawingArea.__init__(self)
+        Gtk.DrawingArea.__init__(self, tooltip_text=tip)
 
         self.set_size_request(40, 40)
 

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -526,7 +526,6 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
     def create_toolbar(self):
         self.toolbar = toolbar.T()
         # request enough space for toolbar items
-        self.toolbar.set_show_arrow(False)
         self.vbox.pack_start(self.toolbar, expand=False, fill=False, padding=0)
 
         # preview

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -432,7 +432,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
             self.four_d_sensitives.append(my_fourway)
 
     def add_warpmenu(self, tip):
-        self.warpmenu = utils.create_option_menu(["None"], tip)
+        self.warpmenu = utils.combo_box_text_with_items(["None"], tip)
         self.warpmenu.set_id_column(0)
 
         def update_warp_param(menu, f):
@@ -483,7 +483,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         res_names = ["%dx%d" % (w, h) for (w, h) in self.resolutions]
 
-        res_menu = utils.create_option_menu(res_names, _("Resolution"))
+        res_menu = utils.combo_box_text_with_items(res_names, _("Resolution"))
 
         def set_selected_resolution(prefs):
             res = (w, h) = (prefs.getint("display", "width"),

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -433,9 +433,10 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
     def add_warpmenu(self, tip):
         self.warpmenu = utils.create_option_menu(["None"], tip)
+        self.warpmenu.set_id_column(0)
 
         def update_warp_param(menu, f):
-            param = utils.get_selected_value(menu)
+            param = menu.get_active_id()
             if param == "None":
                 param = None
 

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -365,6 +365,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.filename = application_widgets.FractalFilename(self.f)
 
         self.preview = gtkfractal.Preview(application.compiler, 48, 48)
+        self.preview.widget.set_tooltip_text(_("Preview"))
 
         theme_provider = Gtk.CssProvider()
         css_file = "gnofract4d.css"
@@ -419,11 +420,8 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.panes.pack2(self.settingsPane, resize=False, shrink=False)
 
     def add_fourway(self, name, tip, axis, is4dsensitive):
-        my_fourway = fourway.T(name)
-        self.toolbar.add_widget(
-            my_fourway,
-            tip,
-            None)
+        my_fourway = fourway.T(name, tip)
+        self.toolbar.add(my_fourway)
 
         my_fourway.axis = axis
 
@@ -434,7 +432,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
             self.four_d_sensitives.append(my_fourway)
 
     def add_warpmenu(self, tip):
-        self.warpmenu = utils.create_option_menu(["None"])
+        self.warpmenu = utils.create_option_menu(["None"], tip)
 
         def update_warp_param(menu, f):
             param = utils.get_selected_value(menu)
@@ -450,13 +448,10 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         self.warpmenu.connect("changed", update_warp_param, self.f)
 
-        self.toolbar.add_widget(
-            self.warpmenu,
-            tip,
-            None)
+        self.toolbar.add(self.warpmenu)
 
     def create_angle_widget(self, name, tip, axis, is4dsensitive):
-        my_angle = angle.T(name)
+        my_angle = angle.T(name, tip)
         my_angle.connect('value-slightly-changed',
                          self.on_angle_slightly_changed)
         my_angle.connect('value-changed',
@@ -467,10 +462,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         my_angle.axis = axis
 
-        self.toolbar.add_widget(
-            my_angle,
-            tip,
-            tip)
+        self.toolbar.add(my_angle)
 
         if is4dsensitive:
             self.four_d_sensitives.append(my_angle)
@@ -490,7 +482,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         res_names = ["%dx%d" % (w, h) for (w, h) in self.resolutions]
 
-        res_menu = utils.create_option_menu(res_names)
+        res_menu = utils.create_option_menu(res_names, _("Resolution"))
 
         def set_selected_resolution(prefs):
             res = (w, h) = (prefs.getint("display", "width"),
@@ -531,10 +523,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         # preview
         self.toolbar.add_space()
 
-        self.toolbar.add_widget(
-            self.preview.widget,
-            _("Preview"),
-            _("Shows what the next operation would do"))
+        self.toolbar.add(self.preview.widget)
 
         # angles
         self.toolbar.add_space()
@@ -580,10 +569,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         res_menu = self.create_resolution_menu()
 
-        self.toolbar.add_widget(
-            res_menu,
-            _("Resolution"),
-            _("Change fractal's resolution"))
+        self.toolbar.add(res_menu)
 
         # undo/redo
         self.toolbar.add_space()
@@ -607,7 +593,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
             "app.ToolsExplorerAction")
 
         # explorer weirdness
-        self.weirdbox = Gtk.Grid()
+        self.weirdbox = Gtk.Grid(tooltip_text=_("Weirdness"))
         self.weirdbox.set_column_homogeneous(False)
         self.weirdbox.set_row_spacing(5)
         self.weirdbox.set_name("weirdbox")
@@ -637,11 +623,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.weirdbox.attach(color_label, 0, 1, 1, 1)
         self.weirdbox.attach(self.color_weirdness, 1, 1, 1, 1)
 
-        self.toolbar.add_widget(
-            self.weirdbox,
-            _("Weirdness"),
-            _("How different to make the random mutant fractals"),
-            expand=True)
+        self.toolbar.add(self.weirdbox)
 
         def on_weirdness_changed(adjustment):
             self.update_subfracts()

--- a/fract4dgui/browser.py
+++ b/fract4dgui/browser.py
@@ -210,7 +210,7 @@ class BrowserDialog(dialog.T):
 
     def create_panes(self):
         # option menu for choosing Inner/Outer/Fractal
-        self.funcTypeMenu = utils.create_option_menu(
+        self.funcTypeMenu = utils.combo_box_text_with_items(
             [_("Fractal Function"),
              _("Outer Coloring Function"),
              _("Inner Coloring Function"),

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -17,13 +17,13 @@ class T(Gtk.DrawingArea):
             None, (GObject.TYPE_INT, GObject.TYPE_INT))
     }
 
-    def __init__(self, text):
+    def __init__(self, text, tip):
         self.button = 0
         self.radius = 0
         self.last_x = 0
         self.last_y = 0
         self.text = text
-        Gtk.DrawingArea.__init__(self)
+        Gtk.DrawingArea.__init__(self, tooltip_text=tip)
 
         self.set_size_request(53, 53)
 

--- a/fract4dgui/gtkfractal.py
+++ b/fract4dgui/gtkfractal.py
@@ -641,7 +641,7 @@ class T(Hidden):
         label.set_valign(Gtk.Align.CENTER)
         table.attach(label, 0, i, 1, 1)
 
-        widget = utils.create_option_menu(param.enum.value)
+        widget = utils.combo_box_text_with_items(param.enum.value)
 
         def set_selected_value(*args):
             try:
@@ -755,7 +755,7 @@ class T(Hidden):
         table.attach(label, 0, i, 1, 1)
 
         funclist = self.construct_function_menu(param, form)
-        widget = utils.create_option_menu(funclist)
+        widget = utils.combo_box_text_with_items(funclist)
 
         formula = form.formula
 

--- a/fract4dgui/gtkfractal.py
+++ b/fract4dgui/gtkfractal.py
@@ -709,9 +709,8 @@ class T(Hidden):
         table.attach(widget, 1, i + 1, 1, 1)
 
         name = self.param_display_name(name, param)
-        fway = fourway.T(name)
         tip = self.param_tip(name, param)
-        fway.set_tooltip_text(tip)
+        fway = fourway.T(name, tip)
         fway.set_hexpand(True)
 
         fway.connect('value-changed', self.fourway_released, order, form)

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -356,11 +356,13 @@ class MainWindow(Actions, ApplicationWindow):
         if params == []:
             self.warpmenu.hide()
         else:
-            utils.set_menu_from_list(self.warpmenu, ["None"] + params)
+            self.warpmenu.remove_all()
+            for entry in ["None"] + params:
+                self.warpmenu.append_text(entry)
             p = f.warp_param
             if p is None:
                 p = "None"
-            utils.set_selected_value(self.warpmenu, p)
+            self.warpmenu.set_active_id(p)
             self.warpmenu.show()
 
     def save_file(self, file):

--- a/fract4dgui/preferences.py
+++ b/fract4dgui/preferences.py
@@ -402,7 +402,7 @@ class PrefsDialog(dialog.T):
         return widget
 
     def create_antialias_menu(self):
-        optMenu = utils.create_option_menu(["None", "Fast", "Best"])
+        optMenu = utils.combo_box_text_with_items(["None", "Fast", "Best"])
 
         def set_widget(*args):
             optMenu.set_active(self.prefs.getint("display", "antialias"))

--- a/fract4dgui/tests/test_angle.py
+++ b/fract4dgui/tests/test_angle.py
@@ -10,14 +10,14 @@ from fract4dgui import angle
 
 class Test(unittest.TestCase):
     def testCreate(self):
-        a = angle.T("hello")
+        a = angle.T("hello", "angle")
         self.assertTrue(a)
         self.assertEqual(a.adjustment.get_lower(), -math.pi)
         self.assertEqual(a.adjustment.get_upper(), math.pi)
         self.assertEqual(a.adjustment.get_value(), 0.0)
 
     def testAngles(self):
-        a = angle.T('foo')
+        a = angle.T("foo", "angle")
 
         self.assertEqual(a.get_current_angle(), 0.0)
 
@@ -28,7 +28,7 @@ class Test(unittest.TestCase):
         self.assertEqual(a.get_current_angle(), math.pi)
 
     def testPointerCoords(self):
-        a = angle.T('foo')
+        a = angle.T("foo", "angle")
 
         # 0 should point right
         self.assertNearlyEqual(
@@ -56,7 +56,7 @@ class Test(unittest.TestCase):
             (0, -(40 - angle.T.ptr_radius)))
 
     def testUpdateFromMouse(self):
-        a = angle.T('foo')
+        a = angle.T("foo", "angle")
         a.update_from_mouse(100, 100)
 
     def assertNearlyEqual(self, a, b):

--- a/fract4dgui/tests/test_fourway.py
+++ b/fract4dgui/tests/test_fourway.py
@@ -13,18 +13,18 @@ from gi.repository import Gdk, Gtk
 
 class Test(unittest.TestCase):
     def testCreate(self):
-        f = fourway.T("hello")
+        f = fourway.T("hello", "fourway")
         self.assertTrue(f)
 
     def testAddToWindow(self):
         w = Gtk.Window()
-        f = fourway.T("wibble")
+        f = fourway.T("wibble", "fourway")
         w.add(f)
         w.show()
         Gtk.main_iteration()
 
     def testMouseButton1(self):
-        f = fourway.T("button1")
+        f = fourway.T("button1", "fourway")
         event = Gdk.EventButton()
         event.button = 1
         event.x, event.y = 1, 1

--- a/fract4dgui/tests/test_utils.py
+++ b/fract4dgui/tests/test_utils.py
@@ -13,16 +13,3 @@ class Test(unittest.TestCase):
         om.append_text("fishy")
         om.set_active(3)
         self.assertEqual(3, om.get_active())
-
-        utils.set_menu_from_list(om, ["hello", "world"])
-        om.set_active(1)
-        item1 = utils.get_selected_value(om)
-        self.assertEqual("world", item1)
-
-        utils.set_selected_value(om, "hello")
-        i = om.get_active()
-        self.assertEqual(0, i)
-
-        utils.set_selected_value(om, "world")
-        i = om.get_active()
-        self.assertEqual(1, i)

--- a/fract4dgui/tests/test_utils.py
+++ b/fract4dgui/tests/test_utils.py
@@ -9,7 +9,7 @@ from fract4dgui import utils
 
 class Test(unittest.TestCase):
     def testOptionMenu(self):
-        om = utils.create_option_menu(["foo", "bar", "Bazniculate Geometry"])
+        om = utils.combo_box_text_with_items(["foo", "bar", "Bazniculate Geometry"])
         om.append_text("fishy")
         om.set_active(3)
         self.assertEqual(3, om.get_active())

--- a/fract4dgui/toolbar.py
+++ b/fract4dgui/toolbar.py
@@ -20,11 +20,6 @@ class T(Gtk.Box):
         self.add(Gtk.Separator(
             orientation=Gtk.Orientation.VERTICAL, margin_start=5, margin_end=5))
 
-    def add_widget(self, widget, tip_text, private_text, expand=False):
-        box = Gtk.Box(hexpand=expand, tooltip_text=tip_text)
-        box.add(widget)
-        self.add(box)
-
     def add_button(self, icon_name, tip_text, action):
         self.add(Gtk.Button(**self.button_args(icon_name, tip_text, action)))
 

--- a/fract4dgui/toolbar.py
+++ b/fract4dgui/toolbar.py
@@ -6,34 +6,29 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 
-class T(Gtk.Toolbar):
+class T(Gtk.Box):
     def __init__(self):
-        Gtk.Toolbar.__init__(self)
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, margin=5, spacing=1)
 
-        self.set_border_width(1)
+    @staticmethod
+    def button_args(icon_name, tip_text, action):
+        icon = Gtk.Image(icon_name=icon_name, icon_size=Gtk.IconSize.LARGE_TOOLBAR, margin=5)
+        return dict(
+            action_name=action, image=icon, relief=Gtk.ReliefStyle.NONE, tooltip_text=tip_text)
 
     def add_space(self):
-        self.insert(Gtk.SeparatorToolItem(), -1)
+        self.add(Gtk.Separator(
+            orientation=Gtk.Orientation.VERTICAL, margin_start=5, margin_end=5))
 
     def add_widget(self, widget, tip_text, private_text, expand=False):
-        toolitem = Gtk.ToolItem()
-        toolitem.add(widget)
-        toolitem.set_expand(expand)
-        toolitem.set_homogeneous(False)
-        toolitem.set_tooltip_text(tip_text)
-        self.insert(toolitem, -1)
+        box = Gtk.Box(hexpand=expand, tooltip_text=tip_text)
+        box.add(widget)
+        self.add(box)
 
     def add_button(self, icon_name, tip_text, action):
-        toolitem = Gtk.ToolButton.new()
-        toolitem.set_icon_name(icon_name)
-        toolitem.set_action_name(action)
-        toolitem.set_tooltip_text(tip_text)
-        self.insert(toolitem, -1)
+        self.add(Gtk.Button(**self.button_args(icon_name, tip_text, action)))
 
     def add_toggle(self, icon_name, tip_text, action):
-        toolitem = Gtk.ToggleToolButton.new()
-        toolitem.set_icon_name(icon_name)
-        toolitem.set_action_name(action)
-        toolitem.set_tooltip_text(tip_text)
-        self.insert(toolitem, -1)
+        toolitem = Gtk.ToggleButton(**self.button_args(icon_name, tip_text, action))
+        self.add(toolitem)
         return toolitem

--- a/fract4dgui/utils.py
+++ b/fract4dgui/utils.py
@@ -37,7 +37,7 @@ def set_file_chooser_filename(chooser, name):
         chooser.set_current_name(os.path.basename(name))
 
 
-def create_option_menu(items, tip=None):
+def combo_box_text_with_items(items, tip=None):
     widget = Gtk.ComboBoxText(tooltip_text=tip)
     for item in items:
         widget.append_text(item)

--- a/fract4dgui/utils.py
+++ b/fract4dgui/utils.py
@@ -37,8 +37,8 @@ def set_file_chooser_filename(chooser, name):
         chooser.set_current_name(os.path.basename(name))
 
 
-def create_option_menu(items):
-    widget = Gtk.ComboBoxText()
+def create_option_menu(items, tip=None):
+    widget = Gtk.ComboBoxText(tooltip_text=tip)
     for item in items:
         widget.append_text(item)
 

--- a/fract4dgui/utils.py
+++ b/fract4dgui/utils.py
@@ -45,34 +45,6 @@ def create_option_menu(items, tip=None):
     return widget
 
 
-def set_menu_from_list(menu, items):
-    model = Gtk.ListStore(str)
-    for item in items:
-        model.append((item,))
-    menu.set_model(model)
-
-
-def get_selected_value(menu):
-    iter = menu.get_active_iter()
-    if not iter:
-        return None
-    val = menu.get_model().get_value(iter, 0)
-    return val
-
-
-def set_selected_value(menu, val):
-    model = menu.get_model()
-    i = 0
-    iter = model.get_iter_first()
-    while iter is not None:
-        item = model.get_value(iter, 0)
-        if item == val:
-            menu.set_active(i)
-            return
-        iter = model.iter_next(iter)
-        i += 1
-
-
 def floatColorFrom256(rgba):
     return [rgba[0] / 255.0, rgba[1] / 255.0, rgba[2] / 255.0, rgba[3] / 255.0]
 


### PR DESCRIPTION
Gtk.Toolbar will go in future, and in fact replacing it with a Gtk.Box allows some simplification.

Also take advantage of the higher-level methods introduced in GTK 3 for Gtk.ComboBoxText to remove the menu model code.

Rename utils.create_option_menu() to combo_box_text_with_items().
