### PR TITLE
Use a GResource XML file

### DIFF
--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -44,7 +44,8 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         # libgirepository1.0-dev required to build PyGObject from source
         # gvfs is needed for Gio.AppInfo.launch_default_for_uri()
-        run: sudo apt install gir1.2-gtk-3.0 gvfs libgirepository1.0-dev xvfb
+        # libxml2-utils provides xmllint for xml-stripblanks in gresource.xml
+        run: sudo apt install gir1.2-gtk-3.0 gvfs libgirepository1.0-dev libxml2-utils xvfb
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage
 coverage.xml
 gnofract4d.egg-info
+gnofract4d.gresource
 MANIFEST
 token
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ To build from source you also need:
 
 - headers for libpng and libjpeg
 - Python headers
+- glib-compile-resources and optionally xmllint
 - pkg-config
 
 On Ubuntu, these can be installed with:
 
-    sudo apt install libjpeg-dev libpng-dev libpython3-dev pkg-config
+    sudo apt install libglib2.0-dev-bin libjpeg-dev libpng-dev libpython3-dev libxml2-utils pkg-config
 
 If FFmpeg is installed it will be possible to create videos.
 

--- a/bin/resources.sh
+++ b/bin/resources.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+glib-compile-resources --sourcedir=fract4dgui --target=gnofract4d.gresource fract4dgui/gnofract4d.gresource.xml

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -372,10 +372,8 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
                                                  theme_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
         # custom icon images for toolbar buttons
-        Gtk.IconTheme.prepend_search_path(Gtk.IconTheme.get_default(),
-                                          os.path.dirname(fractconfig.T.find_resource(
-                                              'explorer_mode.png',
-                                              'pixmaps')))
+        Gtk.IconTheme.add_resource_path(
+            Gtk.IconTheme.get_default(), "/io/github/fract4d/pixmaps")
 
         # window
         self.vbox = Gtk.VBox()

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -1,7 +1,6 @@
 # pylint: disable=no-member
 
 import os
-import sys
 
 import gi
 gi.require_version('Gdk', '3.0')
@@ -379,12 +378,6 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
                                           os.path.dirname(fractconfig.T.find_resource(
                                               'explorer_mode.png',
                                               'pixmaps')))
-
-        # menubar
-        this_path = os.path.dirname(sys.modules[__name__].__file__)
-        builder = Gtk.Builder.new_from_file(os.path.join(this_path, "ui.xml"))
-
-        application.set_menubar(builder.get_object("menubar"))
 
         # command reference
         builder = Gtk.Builder.new_from_file(

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -379,12 +379,6 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
                                               'explorer_mode.png',
                                               'pixmaps')))
 
-        # command reference
-        builder = Gtk.Builder.new_from_file(
-            os.path.join(this_path, "shortcuts-gnofract4d.ui"))
-        self.set_help_overlay(
-            builder.get_object("shortcuts-gnofract4d"))
-
         # window
         self.vbox = Gtk.VBox()
         self.add(self.vbox)

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -366,10 +366,8 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.preview = gtkfractal.Preview(application.compiler, 48, 48)
 
         theme_provider = Gtk.CssProvider()
-        css_file = "gnofract4d.css"
-        this_path = os.path.dirname(sys.modules[__name__].__file__)
-        css_filepath = os.path.join(this_path, css_file)
-        theme_provider.load_from_path(css_filepath)
+        css_file = "/io/github/fract4d/gnofract4d.css"
+        theme_provider.load_from_resource(css_file)
         Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
                                                  theme_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 

--- a/fract4dgui/builder/help-overlay.ui
+++ b/fract4dgui/builder/help-overlay.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <!-- interface-requires gtk+ 3.22 -->
-  <object class="GtkShortcutsWindow" id="shortcuts-gnofract4d">
+  <object class="GtkShortcutsWindow" id="help_overlay">
     <property name="modal">1</property>
     <child>
       <object class="GtkShortcutsSection">

--- a/fract4dgui/builder/menus.ui
+++ b/fract4dgui/builder/menus.ui
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <menu id="menubar">
     <submenu>

--- a/fract4dgui/builder/menus.ui
+++ b/fract4dgui/builder/menus.ui
@@ -176,4 +176,32 @@
       </item>
     </submenu>
   </menu>
+  <menu id="director_menubar">
+    <submenu>
+      <attribute name="label" translatable="yes">_Director</attribute>
+      <item>
+        <attribute name="action">director.new</attribute>
+        <attribute name="label" translatable="yes">_New Animation</attribute>
+        <attribute name="accel">&lt;control&gt;N</attribute>
+      </item>
+      <item>
+        <attribute name="action">director.open</attribute>
+        <attribute name="label" translatable="yes">_Open Animation</attribute>
+        <attribute name="accel">&lt;control&gt;O</attribute>
+      </item>
+      <item>
+        <attribute name="action">director.save</attribute>
+        <attribute name="label" translatable="yes">_Save Animation</attribute>
+        <attribute name="accel">&lt;control&gt;S</attribute>
+      </item>
+    </submenu>
+    <submenu>
+      <attribute name="label" translatable="yes">_Edit</attribute>
+        <item>
+          <attribute name="action">director.edit_prefs</attribute>
+          <attribute name="label" translatable="yes">_Preferences</attribute>
+          <attribute name="accel">&lt;control&gt;P</attribute>
+        </item>
+    </submenu>
+  </menu>
 </interface>

--- a/fract4dgui/builder/menus.ui
+++ b/fract4dgui/builder/menus.ui
@@ -164,6 +164,7 @@
       <item>
         <attribute name="action">win.show-help-overlay</attribute>
         <attribute name="label" translatable="yes">Command _Reference</attribute>
+        <attribute name="accel">&lt;Primary&gt;question</attribute>
       </item>
       <item>
         <attribute name="action">app.HelpReportBugAction</attribute>

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -514,41 +514,8 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
             add_action(name, handler)
         self.insert_action_group("director", actiongroup)
 
-        menu = '''
-<interface>
-  <menu id="menubar">
-    <submenu>
-      <attribute name="label" translatable="yes">_Director</attribute>
-      <item>
-        <attribute name="action">director.new</attribute>
-        <attribute name="label" translatable="yes">_New Animation</attribute>
-        <attribute name="accel">&lt;control&gt;N</attribute>
-      </item>
-      <item>
-        <attribute name="action">director.open</attribute>
-        <attribute name="label" translatable="yes">_Open Animation</attribute>
-        <attribute name="accel">&lt;control&gt;O</attribute>
-      </item>
-      <item>
-        <attribute name="action">director.save</attribute>
-        <attribute name="label" translatable="yes">_Save Animation</attribute>
-        <attribute name="accel">&lt;control&gt;S</attribute>
-      </item>
-    </submenu>
-    <submenu>
-      <attribute name="label" translatable="yes">_Edit</attribute>
-        <item>
-          <attribute name="action">director.edit_prefs</attribute>
-          <attribute name="label" translatable="yes">_Preferences</attribute>
-          <attribute name="accel">&lt;control&gt;P</attribute>
-        </item>
-    </submenu>
-  </menu>
-</interface>
-'''
-
         menubar = Gtk.MenuBar.new_from_model(
-            Gtk.Builder.new_from_string(menu, -1).get_object("menubar"))
+            main_window.application.get_menu_by_id("director_menubar"))
         self.box_main.pack_start(menubar, False, True, 0)
 
         # -----------creating keyframes popup menu model----------------

--- a/fract4dgui/gnofract4d.gresource.xml
+++ b/fract4dgui/gnofract4d.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/github/fract4d/gtk">
+    <file compressed="true" preprocess="xml-stripblanks" alias="menus.ui">builder/menus.ui</file>
+  </gresource>
+</gresources>

--- a/fract4dgui/gnofract4d.gresource.xml
+++ b/fract4dgui/gnofract4d.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/io/github/fract4d/gtk">
+    <file compressed="true" preprocess="xml-stripblanks" alias="help-overlay.ui">builder/help-overlay.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="menus.ui">builder/menus.ui</file>
   </gresource>
 </gresources>

--- a/fract4dgui/gnofract4d.gresource.xml
+++ b/fract4dgui/gnofract4d.gresource.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
+  <gresource prefix="/io/github/fract4d">
+    <file compressed="true">gnofract4d.css</file>
+  </gresource>
   <gresource prefix="/io/github/fract4d/gtk">
     <file compressed="true" preprocess="xml-stripblanks" alias="help-overlay.ui">builder/help-overlay.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="menus.ui">builder/menus.ui</file>

--- a/fract4dgui/gnofract4d.gresource.xml
+++ b/fract4dgui/gnofract4d.gresource.xml
@@ -7,4 +7,8 @@
     <file compressed="true" preprocess="xml-stripblanks" alias="help-overlay.ui">builder/help-overlay.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="menus.ui">builder/menus.ui</file>
   </gresource>
+  <gresource prefix="/io/github/fract4d/pixmaps">
+    <file alias="explorer_mode.png">../pixmaps/explorer_mode.png</file>
+    <file alias="improve_now.png">../pixmaps/improve_now.png</file>
+  </gresource>
 </gresources>

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -5,8 +5,9 @@ import math
 import gi
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gdk, GLib, Gtk
+from gi.repository import Gdk, Gio, GLib, Gtk
 
+from fract4d import fractconfig
 from fract4d_compiler import fc, fracttypes
 from .application_window import Actions, ApplicationWindow
 from . import (model, preferences, autozoom, browser, utils, hig, painter,
@@ -26,6 +27,10 @@ class Application(Gtk.Application):
         self.mainWindow = None
         self.options = options
         self.userConfig = userConfig
+
+        resource = Gio.resource_load(
+            fractconfig.T.find_resource("gnofract4d.gresource", ""))
+        Gio.Resource._register(resource)
 
     def do_startup(self):
         Gtk.Application.do_startup(self)

--- a/fract4dgui/tests/test_director.py
+++ b/fract4dgui/tests/test_director.py
@@ -4,13 +4,26 @@
 
 from unittest.mock import patch
 import os.path
+import sys
 
 from . import testgui
 
-from gi.repository import Gtk
+from gi.repository import Gio, Gtk
 
 from fract4dgui import director, PNGGen, hig
 from fract4d import fractal, animation
+
+
+class Window(Gtk.Window):
+    def __init__(self):
+        super().__init__()
+        this_path = os.path.dirname(sys.modules[__name__].__file__)
+        resource = Gio.resource_load(os.path.join(this_path, "../../gnofract4d.gresource"))
+        Gio.Resource._register(resource)
+        self.menu_builder = Gtk.Builder.new_from_resource("/io/github/fract4d/gtk/menus.ui")
+
+    def get_menu_by_id(self, menuid):
+        return self.menu_builder.get_object(menuid)
 
 
 class Test(testgui.TestCase):
@@ -18,7 +31,7 @@ class Test(testgui.TestCase):
         # ensure any dialog boxes are dismissed without human interaction
         hig.timeout = 250
 
-        application = Gtk.Window()
+        application = Window()
         application.userConfig = Test.userConfig
         self.parent = Gtk.Window()
         self.parent.f = fractal.T(Test.g_comp)

--- a/fract4dgui/tests/test_main_window.py
+++ b/fract4dgui/tests/test_main_window.py
@@ -3,6 +3,7 @@
 # high-level unit tests for main window
 
 import os
+import sys
 import tempfile
 from unittest.mock import patch
 
@@ -23,7 +24,13 @@ class Application(Gtk.Application):
         self.userPrefs = preferences.Preferences(config)
         self.compiler = fc.Compiler(config)
         self.compiler.add_func_path('formulas')
+        this_path = os.path.dirname(sys.modules[__name__].__file__)
+        resource = Gio.resource_load(os.path.join(this_path, "../../gnofract4d.gresource"))
+        Gio.Resource._register(resource)
+        self.menu_builder = Gtk.Builder.new_from_resource("/io/github/fract4d/gtk/menus.ui")
 
+    def get_menu_by_id(self, menuid):
+        return self.menu_builder.get_object(menuid)
 
 class WrapMainWindow(main_window.MainWindow):
     def __init__(self, config):

--- a/setup.py
+++ b/setup.py
@@ -204,14 +204,6 @@ and includes a Fractint-compatible parser for your own fractal formulas.''',
             get_files("help", "png") +
             get_files("help", "css")
         ),
-        # internal pixmaps
-        (
-            'share/gnofract4d/pixmaps',
-            [
-                'pixmaps/improve_now.png',
-                'pixmaps/explorer_mode.png',
-            ]
-        ),
         # icon
         ('share/pixmaps', ['pixmaps/logo/48x48/gnofract4d.png']),
         # theme icons

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,6 @@ and includes a Fractint-compatible parser for your own fractal formulas.''',
     url='http://github.com/fract4d/gnofract4d/',
     packages=['fract4d_compiler', 'fract4d', 'fract4dgui'],
     package_data={
-        'fract4dgui': ['gnofract4d.css'],
         'fract4d': ['c/pf.h', 'c/fract_stdlib.h', 'c/model/imageutils.h', 'c/model/colorutils.h']
     },
     ext_modules=[module_fract4dc],

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ and includes a Fractint-compatible parser for your own fractal formulas.''',
     url='http://github.com/fract4d/gnofract4d/',
     packages=['fract4d_compiler', 'fract4d', 'fract4dgui'],
     package_data={
-        'fract4dgui': ['shortcuts-gnofract4d.ui', 'gnofract4d.css'],
+        'fract4dgui': ['gnofract4d.css'],
         'fract4d': ['c/pf.h', 'c/fract_stdlib.h', 'c/model/imageutils.h', 'c/model/colorutils.h']
     },
     ext_modules=[module_fract4dc],

--- a/setup.py
+++ b/setup.py
@@ -210,11 +210,6 @@ and includes a Fractint-compatible parser for your own fractal formulas.''',
             [
                 'pixmaps/improve_now.png',
                 'pixmaps/explorer_mode.png',
-                'pixmaps/mail-forward.png',
-                'pixmaps/draw-brush.png',
-                'pixmaps/face-sad.png',
-                'pixmaps/autozoom.png',
-                'pixmaps/randomize_colors.png'
             ]
         ),
         # icon


### PR DESCRIPTION
Advantages:

* Gtk.Application loads menus and the shortcuts window definitions automatically.
* 5 files: menus, shortcuts, CSS and the two remaining pixmaps can be combined into one file that is less than half the size of the uncompressed menu file.

Disadvantages:

* Adds a dependency on `glib-compile-resources`, which is bundled with GLib in Homebrew and Gentoo Linux and already installed in the GitHub Actions VMs. It is available in a separate package on Debian/Ubuntu.
* If modifying any of the files during development the GResource file needs to be recreated. This can be done with either `setup.py build` or `./bin/resources.sh`.
