### PR TITLE
Tidy GUI folder

### DIFF
--- a/fract4dgui/AVIGen.py
+++ b/fract4dgui/AVIGen.py
@@ -10,7 +10,6 @@ from gi.repository import Gdk, Gtk, GLib
 
 class AVIGeneration:
     def __init__(self, animation, parent):
-        # pylint: disable=no-member
         self.animation = animation
         self.converterpath = parent.converterpath
         self.error_watch = None
@@ -81,16 +80,18 @@ class AVIGeneration:
         call.extend([
             "-c:v", "libvpx-vp9", "-crf", "30", "-b:v", "0",
             "-r", str(framerate), video_file])
-        self.pid, fd_in, fd_out, fd_err = GLib.spawn_async(call,
-                                                           flags=GLib.SpawnFlags.DO_NOT_REAP_CHILD,
-                                                           standard_output=False, standard_error=True)
+        self.pid, fd_in, fd_out, fd_err = GLib.spawn_async(
+            call,
+            flags=GLib.SpawnFlags.DO_NOT_REAP_CHILD,
+            standard_output=False,
+            standard_error=True)
         self.fh_err = os.fdopen(fd_err, "r")
         GLib.child_watch_add(
             GLib.PRIORITY_DEFAULT,
             self.pid,
             self.video_complete)
-        self.error_watch = GLib.io_add_watch(self.fh_err, GLib.PRIORITY_DEFAULT,
-                                             GLib.IOCondition.IN, self.video_error)
+        self.error_watch = GLib.io_add_watch(
+            self.fh_err, GLib.PRIORITY_DEFAULT, GLib.IOCondition.IN, self.video_error)
 
     def video_error(self, source, condition):
         error_text = source.read()
@@ -122,7 +123,7 @@ class AVIGeneration:
 
         try:
             self.generate_avi()
-        except GLib.GError as err: #pylint: disable=catching-non-exception
+        except GLib.GError as err:  # pylint: disable=catching-non-exception
             error_dlg = Gtk.MessageDialog(
                 transient_for=self.dialog,
                 title=_("Error executing video converter"),

--- a/fract4dgui/DlgAdvOpt.py
+++ b/fract4dgui/DlgAdvOpt.py
@@ -7,10 +7,11 @@
 
 from gi.repository import Gtk
 
+from . import utils
+
 
 class DlgAdvOptions:
     def __init__(self, current_kf, animation, parent):
-        # pylint: disable=no-member
         self.dialog = Gtk.Dialog(
             transient_for=parent,
             title="Keyframe advanced options",
@@ -23,76 +24,25 @@ class DlgAdvOptions:
         self.current_kf = current_kf
         self.animation = animation
 
-        tbl_main = Gtk.Grid()
-        tbl_main.set_row_spacing(10)
-        tbl_main.set_column_spacing(10)
-        tbl_main.set_property("margin", 10)
-
+        tbl_main = Gtk.Grid(row_spacing=10, column_spacing=10, margin=10)
         dirs = animation.get_directions(self.current_kf)
+        self.cmbs = []
+        for i, plane in enumerate(["XY", "XZ", "XW", "YZ", "YW", "ZW"]):
+            tbl_main.attach(
+                Gtk.Label(label=f"{plane} angles interpolation direction:"), 0, i, 1, 1)
+            cmb = utils.combo_box_text_with_items(
+                ["Nearer", "Longer", "Clockwise", "Counterclockwise"])
+            cmb.set_active(dirs[i])
+            tbl_main.attach(cmb, 1, i, 1, 1)
+            self.cmbs.append(cmb)
 
-        lbl_xy = Gtk.Label(label="XY angles interpolation direction:")
-        tbl_main.attach(lbl_xy, 0, 0, 1, 1)
-        self.cmb_xy = Gtk.ComboBoxText()
-        self.cmb_xy.append_text("Nearer")
-        self.cmb_xy.append_text("Longer")
-        self.cmb_xy.append_text("Clockwise")
-        self.cmb_xy.append_text("Counterclockwise")
-        self.cmb_xy.set_active(dirs[0])
-        tbl_main.attach(self.cmb_xy, 1, 0, 1, 1)
-        lbl_xz = Gtk.Label(label="XZ angles interpolation direction:")
-        tbl_main.attach(lbl_xz, 0, 1, 1, 1)
-        self.cmb_xz = Gtk.ComboBoxText()
-        self.cmb_xz.append_text("Nearer")
-        self.cmb_xz.append_text("Longer")
-        self.cmb_xz.append_text("Clockwise")
-        self.cmb_xz.append_text("Counterclockwise")
-        self.cmb_xz.set_active(dirs[1])
-        tbl_main.attach(self.cmb_xz, 1, 1, 1, 1)
-        lbl_xw = Gtk.Label(label="XW angles interpolation direction:")
-        tbl_main.attach(lbl_xw, 0, 2, 1, 1)
-        self.cmb_xw = Gtk.ComboBoxText()
-        self.cmb_xw.append_text("Nearer")
-        self.cmb_xw.append_text("Longer")
-        self.cmb_xw.append_text("Clockwise")
-        self.cmb_xw.append_text("Counterclockwise")
-        self.cmb_xw.set_active(dirs[2])
-        tbl_main.attach(self.cmb_xw, 1, 2, 1, 1)
-        lbl_yz = Gtk.Label(label="YZ angles interpolation direction:")
-        tbl_main.attach(lbl_yz, 0, 3, 1, 1)
-        self.cmb_yz = Gtk.ComboBoxText()
-        self.cmb_yz.append_text("Nearer")
-        self.cmb_yz.append_text("Longer")
-        self.cmb_yz.append_text("Clockwise")
-        self.cmb_yz.append_text("Counterclockwise")
-        self.cmb_yz.set_active(dirs[3])
-        tbl_main.attach(self.cmb_yz, 1, 3, 1, 1)
-        lbl_yw = Gtk.Label(label="YW angles interpolation direction:")
-        tbl_main.attach(lbl_yw, 0, 4, 1, 1)
-        self.cmb_yw = Gtk.ComboBoxText()
-        self.cmb_yw.append_text("Nearer")
-        self.cmb_yw.append_text("Longer")
-        self.cmb_yw.append_text("Clockwise")
-        self.cmb_yw.append_text("Counterclockwise")
-        self.cmb_yw.set_active(dirs[4])
-        tbl_main.attach(self.cmb_yw, 1, 4, 1, 1)
-        lbl_zw = Gtk.Label(label="ZW angles interpolation direction:")
-        tbl_main.attach(lbl_zw, 0, 5, 1, 1)
-        self.cmb_zw = Gtk.ComboBoxText()
-        self.cmb_zw.append_text("Nearer")
-        self.cmb_zw.append_text("Longer")
-        self.cmb_zw.append_text("Clockwise")
-        self.cmb_zw.append_text("Counterclockwise")
-        self.cmb_zw.set_active(dirs[5])
-        tbl_main.attach(self.cmb_zw, 1, 5, 1, 1)
         self.dialog.vbox.pack_start(tbl_main, True, True, 0)
 
     def show(self):
         self.dialog.show_all()
         response = self.dialog.run()
         if response == Gtk.ResponseType.OK:
-            dirs = (self.cmb_xy.get_active(), self.cmb_xz.get_active(),
-                    self.cmb_xw.get_active(), self.cmb_yz.get_active(),
-                    self.cmb_yw.get_active(), self.cmb_zw.get_active())
+            dirs = ([cmb.get_active() for cmb in self.cmbs])
             self.animation.set_directions(self.current_kf, dirs)
 
         self.dialog.destroy()

--- a/fract4dgui/PNGGen.py
+++ b/fract4dgui/PNGGen.py
@@ -14,7 +14,6 @@ running = False
 
 class PNGGeneration(Gtk.Dialog, hig.MessagePopper):
     def __init__(self, animation, compiler, parent):
-        #pylint: disable=no-member
         Gtk.Dialog.__init__(
             self,
             transient_for=parent,
@@ -23,12 +22,10 @@ class PNGGeneration(Gtk.Dialog, hig.MessagePopper):
 
         self.add_buttons(_("_Cancel"), Gtk.ResponseType.CANCEL)
         hig.MessagePopper.__init__(self)
-        self.lbl_image = Gtk.Label(label="Current image progress")
-        self.vbox.pack_start(self.lbl_image, True, True, 0)
+        self.vbox.pack_start(Gtk.Label(label="Current image progress"), True, True, 0)
         self.pbar_image = Gtk.ProgressBar()
         self.vbox.pack_start(self.pbar_image, True, True, 0)
-        self.lbl_overall = Gtk.Label(label="Overall progress")
-        self.vbox.pack_start(self.lbl_overall, True, True, 0)
+        self.vbox.pack_start(Gtk.Label(label="Overall progress"), True, True, 0)
         self.pbar_overall = Gtk.ProgressBar()
         self.vbox.pack_start(self.pbar_overall, True, True, 0)
         geometry = Gdk.Geometry()
@@ -64,7 +61,8 @@ class PNGGeneration(Gtk.Dialog, hig.MessagePopper):
                 try:
                     folder_png = self.anim.get_png_dir()
                     response = self.ask_question(
-                        _("The temporary directory: %s already contains at least one image" % folder_png),
+                        _("The temporary directory: %s already contains"
+                          " at least one image" % folder_png),
                         _("Use them to speed up generation?"))
 
                 except Exception as err:

--- a/fract4dgui/angle.py
+++ b/fract4dgui/angle.py
@@ -33,18 +33,16 @@ class T(Gtk.DrawingArea):
 
         self.adjustment.connect('value-changed', self.onAdjustmentValueChanged)
 
-        Gtk.DrawingArea.__init__(self, tooltip_text=tip)
-
-        self.set_size_request(40, 40)
+        Gtk.DrawingArea.__init__(self, tooltip_text=tip, width_request=40, height_request=40)
 
         self.set_events(
-            Gdk.EventMask.BUTTON_RELEASE_MASK |
-            Gdk.EventMask.BUTTON1_MOTION_MASK |
-            Gdk.EventMask.POINTER_MOTION_HINT_MASK |
-            Gdk.EventMask.ENTER_NOTIFY_MASK |
-            Gdk.EventMask.LEAVE_NOTIFY_MASK |
-            Gdk.EventMask.BUTTON_PRESS_MASK |
-            Gdk.EventMask.EXPOSURE_MASK
+            Gdk.EventMask.BUTTON_RELEASE_MASK
+            | Gdk.EventMask.BUTTON1_MOTION_MASK
+            | Gdk.EventMask.POINTER_MOTION_HINT_MASK
+            | Gdk.EventMask.ENTER_NOTIFY_MASK
+            | Gdk.EventMask.LEAVE_NOTIFY_MASK
+            | Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.EXPOSURE_MASK
         )
 
         self.notice_mouse = False
@@ -69,7 +67,6 @@ class T(Gtk.DrawingArea):
 
     def angle_from_xy(self, x, y):
         angle = math.atan2(y, x)
-        #angle = math.fmod(angle,T.two_pi)
         return angle
 
     def onAdjustmentValueChanged(self, adjustment):

--- a/fract4dgui/angle.py
+++ b/fract4dgui/angle.py
@@ -36,13 +36,13 @@ class T(Gtk.DrawingArea):
         Gtk.DrawingArea.__init__(self, tooltip_text=tip, width_request=40, height_request=40)
 
         self.set_events(
-            Gdk.EventMask.BUTTON_RELEASE_MASK
-            | Gdk.EventMask.BUTTON1_MOTION_MASK
-            | Gdk.EventMask.POINTER_MOTION_HINT_MASK
-            | Gdk.EventMask.ENTER_NOTIFY_MASK
-            | Gdk.EventMask.LEAVE_NOTIFY_MASK
-            | Gdk.EventMask.BUTTON_PRESS_MASK
-            | Gdk.EventMask.EXPOSURE_MASK
+            Gdk.EventMask.BUTTON_RELEASE_MASK |
+            Gdk.EventMask.BUTTON1_MOTION_MASK |
+            Gdk.EventMask.POINTER_MOTION_HINT_MASK |
+            Gdk.EventMask.ENTER_NOTIFY_MASK |
+            Gdk.EventMask.LEAVE_NOTIFY_MASK |
+            Gdk.EventMask.BUTTON_PRESS_MASK |
+            Gdk.EventMask.EXPOSURE_MASK
         )
 
         self.notice_mouse = False

--- a/fract4dgui/application_widgets.py
+++ b/fract4dgui/application_widgets.py
@@ -11,9 +11,7 @@ re_cleanup = re.compile(r'[\s\(\)]+')
 
 class Fract4dOpenChooser(utils.FileOpenChooser):
     def __init__(self, parent, preview):
-        super().__init__(
-            title=_("Open File"),
-            parent=parent)
+        super().__init__(title=_("Open File"),  parent=parent)
 
         self.add_filters()
 
@@ -24,7 +22,7 @@ class Fract4dOpenChooser(utils.FileOpenChooser):
                     preview.loadFctFile(f)
                 preview.draw_image(False, False)
                 active = True
-            except Exception as err:
+            except Exception:
                 active = False
             chooser.set_preview_widget_active(active)
 
@@ -38,8 +36,7 @@ class Fract4dOpenChooser(utils.FileOpenChooser):
         formula_patterns = ["*.frm", "*.ufm", "*.ucl", "*.cfrm", "*.uxf"]
         self.add_file_filter(_("Formula Files"), formula_patterns)
 
-        gradient_patterns = ["*.map", "*.ggr",
-                             "*.ugr", "*.cs", "*.pal", "*.ase"]
+        gradient_patterns = ["*.map", "*.ggr", "*.ugr", "*.cs", "*.pal", "*.ase"]
         self.add_file_filter(_("Gradient Files"), gradient_patterns)
 
         all_filter = self.add_file_filter(

--- a/fract4dgui/autozoom.py
+++ b/fract4dgui/autozoom.py
@@ -9,7 +9,6 @@ from . import dialog
 
 class AutozoomDialog(dialog.T):
     def __init__(self, main_window, f):
-        #pylint: disable=no-member
         dialog.T.__init__(
             self,
             _("Autozoom"),
@@ -19,28 +18,26 @@ class AutozoomDialog(dialog.T):
 
         self.f = f
 
-        table = Gtk.Grid()
-        table.set_column_spacing(5)
-        table.set_row_spacing(5)
+        table = Gtk.Grid(column_spacing=5, row_spacing=5)
         self.vbox.add(table)
 
-        self.zoombutton = Gtk.ToggleButton(label=_("Start _Zooming"))
-        self.zoombutton.set_tooltip_text(
-            _("Zoom into interesting areas automatically"))
-        self.zoombutton.set_use_underline(True)
+        self.zoombutton = Gtk.ToggleButton(
+            label=_("Start _Zooming"),
+            tooltip_text=_("Zoom into interesting areas automatically"),
+            use_underline=True)
         self.zoombutton.connect('toggled', self.onZoomToggle)
         f.connect('status-changed', self.onStatusChanged)
         table.attach(self.zoombutton, 0, 0, 2, 1)
 
         self.minsize = 1.0E-13  # FIXME, should calculate this better
 
-        self.minsize_entry = Gtk.Entry()
-        self.minsize_entry.set_tooltip_text(
-            _("Stop zooming when size of fractal is this small"))
-        minlabel = Gtk.Label(label=_("_Min Size"))
+        self.minsize_entry = Gtk.Entry(
+            tooltip_text=_("Stop zooming when size of fractal is this small"))
+        minlabel = Gtk.Label(
+            label=_("_Min Size"),
+            use_underline=True,
+            mnemonic_widget=self.minsize_entry)
         table.attach(minlabel, 0, 1, 1, 1)
-        minlabel.set_use_underline(True)
-        minlabel.set_mnemonic_widget(self.minsize_entry)
 
         def set_entry(*args):
             self.minsize_entry.set_text("%g" % self.minsize)

--- a/fract4dgui/browser.py
+++ b/fract4dgui/browser.py
@@ -6,8 +6,6 @@ from gi.repository import Gtk, GObject
 
 from . import dialog, utils, gtkfractal, browser_model
 
-# pylint: disable=no-member
-
 
 class BrowserDialog(dialog.T):
     RESPONSE_REFRESH = 2
@@ -98,21 +96,16 @@ class BrowserDialog(dialog.T):
         self.model.set_type(type)
 
     def create_file_list(self):
-        sw = Gtk.ScrolledWindow()
+        sw = Gtk.ScrolledWindow(
+            shadow_type=Gtk.ShadowType.ETCHED_IN,
+            hscrollbar_policy=Gtk.PolicyType.NEVER)
 
-        sw.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
-        sw.set_policy(Gtk.PolicyType.NEVER,
-                      Gtk.PolicyType.AUTOMATIC)
-
-        self.filetreeview = Gtk.TreeView.new_with_model(self.file_list)
-        self.filetreeview.set_tooltip_text(
-            _("A list of files containing fractal formulas"))
-
+        self.filetreeview = Gtk.TreeView(
+            model=self.file_list,
+            tooltip_text=_("A list of files containing fractal formulas"))
         sw.add(self.filetreeview)
 
-        renderer = Gtk.CellRendererText()
-        column = Gtk.TreeViewColumn('_File', renderer, text=0)
-
+        column = Gtk.TreeViewColumn('_File', Gtk.CellRendererText(), text=0)
         self.filetreeview.append_column(column)
 
         return sw
@@ -175,33 +168,23 @@ class BrowserDialog(dialog.T):
             'changed', self.formula_selection_changed)
 
     def create_formula_list(self):
-        sw = Gtk.ScrolledWindow()
-        sw.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
-        sw.set_policy(Gtk.PolicyType.NEVER,
-                      Gtk.PolicyType.AUTOMATIC)
+        sw = Gtk.ScrolledWindow(
+            shadow_type=Gtk.ShadowType.ETCHED_IN,
+            hscrollbar_policy=Gtk.PolicyType.NEVER)
 
-        self.treeview = Gtk.TreeView.new_with_model(self.formula_list)
-
-        self.treeview.set_tooltip_text(
-            _("A list of formulas in the selected file"))
-
+        self.treeview = Gtk.TreeView(
+            model=self.formula_list,
+            tooltip_text=_("A list of formulas in the selected file"))
         sw.add(self.treeview)
 
-        renderer = Gtk.CellRendererText()
-        column = Gtk.TreeViewColumn(_('F_ormula'), renderer, text=0)
+        column = Gtk.TreeViewColumn(_('F_ormula'), Gtk.CellRendererText(), text=0)
         self.treeview.append_column(column)
 
         return sw
 
     def create_scrolled_textview(self, tip):
-        sw = Gtk.ScrolledWindow()
-        sw.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
-        sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-
-        textview = Gtk.TextView()
-        textview.set_tooltip_text(tip)
-        textview.set_editable(False)
-
+        sw = Gtk.ScrolledWindow(shadow_type=Gtk.ShadowType.ETCHED_IN)
+        textview = Gtk.TextView(tooltip_text=tip, editable=False)
         sw.add(textview)
         return (textview, sw)
 
@@ -212,35 +195,29 @@ class BrowserDialog(dialog.T):
              _("Outer Coloring Function"),
              _("Inner Coloring Function"),
              _("Transform Function"),
-             _("Gradient")])
-
-        self.funcTypeMenu.set_active(int(self.model.current_type))
-
-        self.funcTypeMenu.set_tooltip_text(
+             _("Gradient")],
             _("Which formula of the current fractal to change"))
-
+        self.funcTypeMenu.set_active(int(self.model.current_type))
         self.funcTypeMenu.connect('changed', self.set_type_cb)
 
         # label for the menu
-        hbox = Gtk.HBox()
-        label = Gtk.Label(label=_("Function _Type to Modify : "))
-        label.set_use_underline(True)
-        label.set_mnemonic_widget(self.funcTypeMenu)
-
+        hbox = Gtk.Box()
+        label = Gtk.Label(
+            label=_("Function _Type to Modify : "),
+            use_underline=True,
+            mnemonic_widget=self.funcTypeMenu)
         hbox.pack_start(label, False, False, 0)
-
         hbox.pack_start(self.funcTypeMenu, True, True, 0)
         self.vbox.pack_start(hbox, False, False, 0)
 
         # 3 panes: files, formulas, formula contents
-        panes1 = Gtk.HPaned()
+        panes1 = Gtk.Paned(border_width=5)
         self.vbox.pack_start(panes1, True, True, 0)
-        panes1.set_border_width(5)
 
         file_list = self.create_file_list()
         formula_list = self.create_formula_list()
 
-        panes2 = Gtk.HPaned()
+        panes2 = Gtk.Paned()
         # left-hand pane displays file list
         panes2.pack1(file_list, True, False)
         # middle is formula list for that file
@@ -251,24 +228,21 @@ class BrowserDialog(dialog.T):
         notebook = Gtk.Notebook()
 
         # preview
-        label = Gtk.Label(label=_('_Preview'))
-        label.set_use_underline(True)
+        label = Gtk.Label(label=_('_Preview'), use_underline=True)
         notebook.append_page(self.preview.widget, label)
 
         # source
         (self.sourcetext, sw) = self.create_scrolled_textview(
             _("The contents of the currently selected formula file"))
 
-        label = Gtk.Label(label=_('_Source'))
-        label.set_use_underline(True)
+        label = Gtk.Label(label=_('_Source'), use_underline=True)
         notebook.append_page(sw, label)
 
         # messages
         (self.msgtext, sw) = self.create_scrolled_textview(
             _("Any compiler warnings or errors in the current function"))
 
-        label = Gtk.Label(label=_('_Messages'))
-        label.set_use_underline(True)
+        label = Gtk.Label(label=_('_Messages'), use_underline=True)
         notebook.append_page(sw, label)
 
         panes1.add2(notebook)

--- a/fract4dgui/director.py
+++ b/fract4dgui/director.py
@@ -37,7 +37,8 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
             fct_dir += "/"
         if keydir == fct_dir:
             raise SanityCheckError(
-                _("Keyframe %s is in the temporary .fct directory and could be overwritten. Please change temp directory." % keyframe))
+                _("Keyframe %s is in the temporary .fct directory and could be overwritten."
+                  " Please change temp directory." % keyframe))
 
     def check_fct_file_sanity(self):
         # things to check with fct temp dir
@@ -407,7 +408,6 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
 
     # creating window...
     def __init__(self, main_window):
-        #pylint: disable=no-member
         dialog.T.__init__(
             self,
             _("Director"),
@@ -422,8 +422,7 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
         self.animation = animation.T(self.compiler, main_window.application.userConfig)
 
         # main VBox
-        self.box_main = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
-        self.box_main.set_homogeneous(False)
+        box_main = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         # --------------------menu-------------------------------
         accelgroup = Gtk.AccelGroup()
         self.add_accel_group(accelgroup)
@@ -459,7 +458,7 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
 
         menubar = Gtk.MenuBar.new_from_model(
             main_window.application.get_menu_by_id("director_menubar"))
-        self.box_main.pack_start(menubar, False, True, 0)
+        box_main.pack_start(menubar, False, True, 0)
 
         # -----------creating keyframes popup menu model----------------
         add_action("file_keyframe", self.add_from_file)
@@ -469,52 +468,22 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
         popup_menu.append("From file", "director.file_keyframe")
         popup_menu.append("From current fractal", "director.current_keyframe")
         # --------------Keyframes box-----------------------------------
-        self.frm_kf = Gtk.Frame.new("Keyframes")
-        self.frm_kf.set_border_width(10)
-        vbox_kfs = Gtk.Box.new(Gtk.Orientation.VERTICAL, 8)
-        button_box_kfs = Gtk.ButtonBox()
-        button_box_kfs.set_layout(Gtk.ButtonBoxStyle.SPREAD)
-        self.sw = Gtk.ScrolledWindow()
-        self.sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        self.sw.set_size_request(-1, 100)
-#        filenames=Gtk.ListStore(GObject.TYPE_STRING,
-#            GObject.TYPE_STRING)
-#        self.tv_keyframes=Gtk.TreeView(filenames)
-#        self.tv_column_name = Gtk.TreeViewColumn('Keyframes')
-#        self.tv_keyframes.append_column(self.tv_column_name)
-#        self.tv_column_duration = Gtk.TreeViewColumn('Duration')
-#        self.tv_keyframes.append_column(self.tv_column_duration)
-#        self.cell_name = Gtk.CellRendererText()
-#        self.tv_column_name.pack_start(self.cell_name, True)
-#        self.tv_column_name.add_attribute(self.cell_name, 'text', 0)
-#        self.cell_duration = Gtk.CellRendererText()
-#        self.tv_column_name.pack_start(self.cell_duration, True)
-#        self.tv_column_name.add_attribute(self.cell_duration, 'text', 0)
-        filenames = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_UINT,
-                                  GObject.TYPE_UINT, GObject.TYPE_STRING)
-        self.tv_keyframes = Gtk.TreeView()
-        self.tv_keyframes.set_model(filenames)
-        column = Gtk.TreeViewColumn(
-            'Keyframes', Gtk.CellRendererText(), text=0)
-        self.tv_keyframes.append_column(column)
+        frm_kf = Gtk.Frame(label="Keyframes", border_width=10)
+        vbox_kfs = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        button_box_kfs = Gtk.ButtonBox(layout_style=Gtk.ButtonBoxStyle.SPREAD)
+        sw = Gtk.ScrolledWindow(width_request=-1, height_request=100)
 
-        column = Gtk.TreeViewColumn(
-            'Stopped for', Gtk.CellRendererText(), text=2)
-        self.tv_keyframes.append_column(column)
-
-        column = Gtk.TreeViewColumn(
-            'Transition duration',
-            Gtk.CellRendererText(),
-            text=1)
-        self.tv_keyframes.append_column(column)
-
-        column = Gtk.TreeViewColumn(
-            'Interpolation type',
-            Gtk.CellRendererText(),
-            text=3)
-        self.tv_keyframes.append_column(column)
-
-        self.sw.add(self.tv_keyframes)
+        filenames = Gtk.ListStore(str, int, int, str)
+        self.tv_keyframes = Gtk.TreeView(model=filenames)
+        self.tv_keyframes.append_column(Gtk.TreeViewColumn(
+            title='Keyframes', cell_renderer=Gtk.CellRendererText(), text=0))
+        self.tv_keyframes.append_column(Gtk.TreeViewColumn(
+            title='Stopped for', cell_renderer=Gtk.CellRendererText(), text=2))
+        self.tv_keyframes.append_column(Gtk.TreeViewColumn(
+            title='Transition duration', cell_renderer=Gtk.CellRendererText(), text=1))
+        self.tv_keyframes.append_column(Gtk.TreeViewColumn(
+            title='Interpolation type', cell_renderer=Gtk.CellRendererText(), text=3))
+        sw.add(self.tv_keyframes)
         self.tv_keyframes.get_selection().connect(
             "changed", self.selection_changed, None)
         self.tv_keyframes.get_selection().set_select_function(self.before_selection, None)
@@ -522,168 +491,140 @@ class DirectorDialog(dialog.T, hig.MessagePopper):
 
         self.btn_add_keyframe = Gtk.MenuButton(label="Add", menu_model=popup_menu)
 
-        self.btn_remove_keyframe = Gtk.Button.new_with_label("Remove")
-        self.btn_remove_keyframe.connect(
-            "clicked", self.remove_keyframe_clicked, None)
+        btn_remove_keyframe = Gtk.Button(label="Remove")
+        btn_remove_keyframe.connect("clicked", self.remove_keyframe_clicked, None)
 
         button_box_kfs.pack_start(self.btn_add_keyframe, True, True, 0)
-        button_box_kfs.pack_start(self.btn_remove_keyframe, True, True, 0)
+        button_box_kfs.pack_start(btn_remove_keyframe, True, True, 0)
 
-        vbox_kfs.pack_start(self.sw, True, True, 0)
+        vbox_kfs.pack_start(sw, True, True, 0)
         vbox_kfs.pack_start(button_box_kfs, True, True, 10)
 
-        self.frm_kf.add(vbox_kfs)
-        self.box_main.pack_start(self.frm_kf, True, True, 0)
+        frm_kf.add(vbox_kfs)
+        box_main.pack_start(frm_kf, True, True, 0)
 
         # current keyframe box
-        self.current_kf = Gtk.Frame.new("Current Keyframe")
-        self.current_kf.set_border_width(10)
+        current_kf = Gtk.Frame(label="Current Keyframe", border_width=10)
+        box_main.pack_start(current_kf, True, True, 0)
 
-        self.box_main.pack_start(self.current_kf, True, True, 0)
+        tbl_keyframes_right = Gtk.Grid(
+            column_homogeneous=True,
+            row_homogeneous=True,
+            row_spacing=10,
+            column_spacing=10,
+            border_width=10)
 
-        self.tbl_keyframes_right = Gtk.Grid()
-        self.tbl_keyframes_right.set_column_homogeneous(True)
-        self.tbl_keyframes_right.set_row_homogeneous(True)
-        self.tbl_keyframes_right.set_row_spacing(10)
-        self.tbl_keyframes_right.set_column_spacing(10)
-        self.tbl_keyframes_right.set_border_width(10)
+        tbl_keyframes_right.attach(Gtk.Label(label="Keyframe stopped for:"), 0, 0, 1, 1)
 
-        self.lbl_kf_stop = Gtk.Label(label="Keyframe stopped for:")
-        self.tbl_keyframes_right.attach(self.lbl_kf_stop, 0, 0, 1, 1)
-
-        adj_kf_stop = Gtk.Adjustment.new(1, 1, 10000, 1, 10, 0)
-        self.spin_kf_stop = Gtk.SpinButton()
-        self.spin_kf_stop.set_adjustment(adj_kf_stop)
+        self.spin_kf_stop = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment.new(1, 1, 10000, 1, 10, 0))
         self.spin_kf_stop.connect("output", self.stop_changed, None)
-        self.tbl_keyframes_right.attach(self.spin_kf_stop, 1, 0, 1, 1)
+        tbl_keyframes_right.attach(self.spin_kf_stop, 1, 0, 1, 1)
 
-        self.lbl_duration = Gtk.Label(label="Transition duration:")
-        self.tbl_keyframes_right.attach(self.lbl_duration, 0, 1, 1, 1)
+        tbl_keyframes_right.attach(Gtk.Label(label="Transition duration:"), 0, 1, 1, 1)
 
-        adj_duration = Gtk.Adjustment.new(25, 1, 10000, 1, 10, 0)
-        self.spin_duration = Gtk.SpinButton()
-        self.spin_duration.set_adjustment(adj_duration)
+        self.spin_duration = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment.new(25, 1, 10000, 1, 10, 0))
         self.spin_duration.connect("output", self.duration_changed, None)
-        self.tbl_keyframes_right.attach(self.spin_duration, 1, 1, 1, 1)
+        tbl_keyframes_right.attach(self.spin_duration, 1, 1, 1, 1)
 
-        self.lbl_int_type = Gtk.Label(label="Interpolation type:")
-        self.tbl_keyframes_right.attach(self.lbl_int_type, 0, 2, 1, 1)
+        tbl_keyframes_right.attach(Gtk.Label(label="Interpolation type:"), 0, 2, 1, 1)
 
-        self.cmb_interpolation_type = Gtk.ComboBoxText()  # Gtk.ComboBox()
-        self.cmb_interpolation_type.append_text("Linear")
-        self.cmb_interpolation_type.append_text("Logarithmic")
-        self.cmb_interpolation_type.append_text("Inverse logarithmic")
-        self.cmb_interpolation_type.append_text("Cosine")
+        self.cmb_interpolation_type = utils.combo_box_text_with_items(
+            ["Linear", "Logarithmic", "Inverse logarithmic", "Cosine"])
         self.cmb_interpolation_type.set_active(0)
         self.cmb_interpolation_type.connect(
             "changed", self.interpolation_type_changed, None)
-        self.tbl_keyframes_right.attach(
+        tbl_keyframes_right.attach(
             self.cmb_interpolation_type, 1, 2, 1, 1)
 
-        self.btn_adv_opt = Gtk.Button(label="Advanced options")
-        self.btn_adv_opt.connect("clicked", self.adv_opt_clicked, None)
-        self.tbl_keyframes_right.attach(self.btn_adv_opt, 0, 3, 2, 1)
+        btn_adv_opt = Gtk.Button(label="Advanced options")
+        btn_adv_opt.connect("clicked", self.adv_opt_clicked, None)
+        tbl_keyframes_right.attach(btn_adv_opt, 0, 3, 2, 1)
 
-        self.current_kf.add(self.tbl_keyframes_right)
+        current_kf.add(tbl_keyframes_right)
         # -------------------------------------------------------------------
         # ----------------------output box-----------------------------------
-        self.frm_output = Gtk.Frame.new("Output options")
-        self.frm_output.set_border_width(10)
+        frm_output = Gtk.Frame(label="Output options", border_width=10)
 
-        self.box_output_main = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
-                                       homogeneous=True, spacing=10)
-        self.box_output_main.set_border_width(10)
-        self.box_output_file = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
-                                       homogeneous=False, spacing=10)
+        box_output_main = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            homogeneous=True,
+            spacing=10,
+            border_width=10)
 
-        self.lbl_temp_avi = Gtk.Label(label="Resulting video file:")
-        self.box_output_file.pack_start(self.lbl_temp_avi, False, False, 10)
+        box_output_file = Gtk.Box(spacing=10)
 
+        box_output_file.pack_start(Gtk.Label(label="Resulting video file:"), False, False, 10)
         self.txt_temp_avi = Gtk.Entry()
-        self.box_output_file.pack_start(self.txt_temp_avi, True, True, 10)
+        box_output_file.pack_start(self.txt_temp_avi, True, True, 10)
 
-        self.btn_temp_avi = Gtk.Button(label="Browse")
-        self.btn_temp_avi.connect("clicked", self.temp_avi_clicked, None)
-        self.box_output_file.pack_start(self.btn_temp_avi, True, True, 10)
+        btn_temp_avi = Gtk.Button(label="Browse")
+        btn_temp_avi.connect("clicked", self.temp_avi_clicked, None)
+        box_output_file.pack_start(btn_temp_avi, True, True, 10)
 
-        self.box_output_main.pack_start(self.box_output_file, True, True, 0)
+        box_output_main.pack_start(box_output_file, True, True, 0)
 
-        self.box_output_res = Gtk.HBox(homogeneous=False, spacing=10)
+        box_output_res = Gtk.Box(spacing=10)
 
-        self.lbl_res = Gtk.Label(label="Resolution:")
-        self.box_output_res.pack_start(self.lbl_res, False, False, 10)
+        box_output_res.pack_start(Gtk.Label(label="Resolution:"), False, False, 10)
+        self.spin_width = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment.new(640, 320, 2048, 10, 100, 0))
+        box_output_res.pack_start(self.spin_width, False, False, 10)
 
-        adj_width = Gtk.Adjustment.new(640, 320, 2048, 10, 100, 0)
-        self.spin_width = Gtk.SpinButton()
-        self.spin_width.set_adjustment(adj_width)
-        self.box_output_res.pack_start(self.spin_width, False, False, 10)
+        box_output_res.pack_start(Gtk.Label(label="x"), False, False, 10)
+        self.spin_height = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment.new(480, 240, 1536, 10, 100, 0))
+        box_output_res.pack_start(self.spin_height, False, False, 10)
 
-        self.lbl_x = Gtk.Label(label="x")
-        self.box_output_res.pack_start(self.lbl_x, False, False, 10)
+        box_output_main.pack_start(box_output_res, True, True, 0)
 
-        adj_height = Gtk.Adjustment.new(480, 240, 1536, 10, 100, 0)
-        self.spin_height = Gtk.SpinButton()
-        self.spin_height.set_adjustment(adj_height)
-        self.box_output_res.pack_start(self.spin_height, False, False, 10)
+        box_output_framerate = Gtk.Box(spacing=10)
 
-        self.box_output_main.pack_start(self.box_output_res, True, True, 0)
-
-        self.box_output_framerate = Gtk.HBox(homogeneous=False, spacing=10)
-
-        self.lbl_framerate = Gtk.Label(label="Frame rate:")
-        self.box_output_framerate.pack_start(
-            self.lbl_framerate, False, False, 10)
-
-        adj_framerate = Gtk.Adjustment.new(25, 5, 100, 1, 5, 0)
-        self.spin_framerate = Gtk.SpinButton()
-        self.spin_framerate.set_adjustment(adj_framerate)
-        self.box_output_framerate.pack_start(
-            self.spin_framerate, False, False, 10)
+        box_output_framerate.pack_start(Gtk.Label(label="Frame rate:"), False, False, 10)
+        self.spin_framerate = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment.new(25, 5, 100, 1, 5, 0))
+        box_output_framerate.pack_start(self.spin_framerate, False, False, 10)
 
         self.chk_swapRB = Gtk.CheckButton(label="Swap red and blue component")
-        self.box_output_framerate.pack_start(self.chk_swapRB, False, False, 50)
+        box_output_framerate.pack_start(self.chk_swapRB, False, False, 50)
 
-        self.box_output_main.pack_start(
-            self.box_output_framerate, True, True, 0)
+        box_output_main.pack_start(box_output_framerate, True, True, 0)
 
-        self.frm_output.add(self.box_output_main)
-        self.box_main.pack_start(self.frm_output, False, False, 0)
+        frm_output.add(box_output_main)
+        box_main.pack_start(frm_output, False, False, 0)
 
         # check if video converter can be found
         self.converterpath = fractconfig.T.find_on_path("ffmpeg")
         if not self.converterpath:
             # put a message at the bottom to warn user
-            warning_box = Gtk.HBox()
-            image = Gtk.Image.new_from_icon_name(
-                "dialog-warning", Gtk.IconSize.BUTTON)
+            warning_box = Gtk.Box()
 
+            image = Gtk.Image(icon_name="dialog-warning", icon_size=Gtk.IconSize.BUTTON)
             warning_box.pack_start(image, True, True, 0)
 
             message = Gtk.Label(label=_(
-                "ffmpeg utility not found. Without it we can't generate any video but can still save sequences of still images."))
-
-            message.set_line_wrap(True)
+                "ffmpeg utility not found. Without it we can't generate any video"
+                " but can still save sequences of still images."),
+                wrap=True)
             warning_box.pack_start(message, True, True, 0)
-            self.box_main.pack_end(warning_box, True, True, 0)
+
+            box_main.pack_end(warning_box, True, True, 0)
 
         # initialise default settings
         self.updateGUI()
 
         # don't connect signals until after settings initialised
         self.spin_height.connect(
-            "value-changed",
-            self.output_height_changed,
-            None)
+            "value-changed", self.output_height_changed, None)
         self.spin_width.connect(
-            "value-changed",
-            self.output_width_changed,
-            None)
+            "value-changed", self.output_width_changed, None)
         self.spin_framerate.connect(
             "value-changed", self.output_framerate_changed, None)
         self.chk_swapRB.connect("toggled", self.swap_redblue_clicked, None)
 
         # --------------showing all-------------------------------
-        self.vbox.add(self.box_main)
+        self.vbox.add(box_main)
         self.vbox.show_all()
 
     def onResponse(self, widget, id):

--- a/fract4dgui/director_prefs.py
+++ b/fract4dgui/director_prefs.py
@@ -32,7 +32,6 @@ class DirectorPrefs:
             self.txt_temp_png.set_text(fold)
 
     def __init__(self, animation, parent):
-        # pylint: disable=no-member
         self.dialog = Gtk.Dialog(title="Director preferences...",
                                  transient_for=parent,
                                  modal=True, destroy_with_parent=True)
@@ -41,24 +40,16 @@ class DirectorPrefs:
 
         self.animation = animation
         # -----------Temporary directories---------------------
-        #self.frm_dirs=Gtk.Frame("Temporary directories selection")
-        # self.frm_dirs.set_border_width(10)
-        tbl_dirs = Gtk.Grid()
-        tbl_dirs.set_row_spacing(10)
-        tbl_dirs.set_column_spacing(10)
-        tbl_dirs.set_property("margin", 10)
+        tbl_dirs = Gtk.Grid(row_spacing=10, column_spacing=10, margin=10)
 
-        lbl_temp_fct = Gtk.Label(label="Temporary directory for .fct files:")
-        tbl_dirs.attach(lbl_temp_fct, 0, 1, 1, 1)
+        tbl_dirs.attach(
+            Gtk.Label(label="Temporary directory for .fct files:"), 0, 1, 1, 1)
 
-        self.txt_temp_fct = Gtk.Entry()
-        self.txt_temp_fct.set_text(self.animation.get_fct_dir())
-        self.txt_temp_fct.set_sensitive(False)
+        self.txt_temp_fct = Gtk.Entry(text=self.animation.get_fct_dir(), sensitive=False)
         tbl_dirs.attach(self.txt_temp_fct, 1, 1, 1, 1)
 
-        self.btn_temp_fct = Gtk.Button(label="Browse")
+        self.btn_temp_fct = Gtk.Button(label="Browse", sensitive=False)
         self.btn_temp_fct.connect("clicked", self.temp_fct_clicked, None)
-        self.btn_temp_fct.set_sensitive(False)
         tbl_dirs.attach(self.btn_temp_fct, 2, 1, 1, 1)
 
         # this check box goes after (even if it's above above widgets because
@@ -70,20 +61,17 @@ class DirectorPrefs:
         self.chk_create_fct.set_active(self.animation.get_fct_enabled())
         tbl_dirs.attach(self.chk_create_fct, 0, 0, 1, 1)
 
-        lbl_temp_png = Gtk.Label(label="Temporary directory for .png files:")
-        tbl_dirs.attach(lbl_temp_png, 0, 2, 1, 1)
+        tbl_dirs.attach(
+            Gtk.Label(label="Temporary directory for .png files:"), 0, 2, 1, 1)
 
-        self.txt_temp_png = Gtk.Entry()
-        self.txt_temp_png.set_text(self.animation.get_png_dir())
+        self.txt_temp_png = Gtk.Entry(text=self.animation.get_png_dir())
         tbl_dirs.attach(self.txt_temp_png, 1, 2, 1, 1)
 
         btn_temp_png = Gtk.Button(label="Browse")
         btn_temp_png.connect("clicked", self.temp_png_clicked, None)
         tbl_dirs.attach(btn_temp_png, 2, 2, 1, 1)
 
-        # self.frm_dirs.add(tbl_dirs)
         self.dialog.vbox.pack_start(tbl_dirs, False, False, 0)
-        # self.dialog.vbox.pack_start(self.tbl_main,True,True,0)
 
         self.dialog.connect('response', self.onResponse)
 

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -22,13 +22,13 @@ class T(Gtk.DrawingArea):
         Gtk.DrawingArea.__init__(self, tooltip_text=tip, width_request=53, height_request=53)
 
         self.set_events(
-            Gdk.EventMask.BUTTON_RELEASE_MASK
-            | Gdk.EventMask.BUTTON1_MOTION_MASK
-            | Gdk.EventMask.POINTER_MOTION_HINT_MASK
-            | Gdk.EventMask.ENTER_NOTIFY_MASK
-            | Gdk.EventMask.LEAVE_NOTIFY_MASK
-            | Gdk.EventMask.BUTTON_PRESS_MASK
-            | Gdk.EventMask.EXPOSURE_MASK
+            Gdk.EventMask.BUTTON_RELEASE_MASK |
+            Gdk.EventMask.BUTTON1_MOTION_MASK |
+            Gdk.EventMask.POINTER_MOTION_HINT_MASK |
+            Gdk.EventMask.ENTER_NOTIFY_MASK |
+            Gdk.EventMask.LEAVE_NOTIFY_MASK |
+            Gdk.EventMask.BUTTON_PRESS_MASK |
+            Gdk.EventMask.EXPOSURE_MASK
         )
 
         self.notice_mouse = False

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -19,18 +19,16 @@ class T(Gtk.DrawingArea):
         self.last_x = 0
         self.last_y = 0
         self.text = text
-        Gtk.DrawingArea.__init__(self, tooltip_text=tip)
-
-        self.set_size_request(53, 53)
+        Gtk.DrawingArea.__init__(self, tooltip_text=tip, width_request=53, height_request=53)
 
         self.set_events(
-            Gdk.EventMask.BUTTON_RELEASE_MASK |
-            Gdk.EventMask.BUTTON1_MOTION_MASK |
-            Gdk.EventMask.POINTER_MOTION_HINT_MASK |
-            Gdk.EventMask.ENTER_NOTIFY_MASK |
-            Gdk.EventMask.LEAVE_NOTIFY_MASK |
-            Gdk.EventMask.BUTTON_PRESS_MASK |
-            Gdk.EventMask.EXPOSURE_MASK
+            Gdk.EventMask.BUTTON_RELEASE_MASK
+            | Gdk.EventMask.BUTTON1_MOTION_MASK
+            | Gdk.EventMask.POINTER_MOTION_HINT_MASK
+            | Gdk.EventMask.ENTER_NOTIFY_MASK
+            | Gdk.EventMask.LEAVE_NOTIFY_MASK
+            | Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.EXPOSURE_MASK
         )
 
         self.notice_mouse = False
@@ -55,8 +53,8 @@ class T(Gtk.DrawingArea):
     def onButtonRelease(self, widget, event):
         if event.button == 1:
             self.notice_mouse = False
-            (xc, yc) = (widget.get_allocated_width() //
-                        2, widget.get_allocated_height() // 2)
+            (xc, yc) = (widget.get_allocated_width() // 2,
+                        widget.get_allocated_height() // 2)
             dx = xc - self.last_x
             dy = yc - self.last_y
             if dx or dy:

--- a/fract4dgui/gtkfractal.py
+++ b/fract4dgui/gtkfractal.py
@@ -463,14 +463,14 @@ class T(Hidden):
 
         drawing_area = Gtk.DrawingArea()
         drawing_area.set_events(
-            Gdk.EventMask.BUTTON_RELEASE_MASK
-            | Gdk.EventMask.BUTTON1_MOTION_MASK
-            | Gdk.EventMask.POINTER_MOTION_MASK
-            | Gdk.EventMask.POINTER_MOTION_HINT_MASK
-            | Gdk.EventMask.BUTTON_PRESS_MASK
-            | Gdk.EventMask.KEY_PRESS_MASK
-            | Gdk.EventMask.KEY_RELEASE_MASK
-            | Gdk.EventMask.EXPOSURE_MASK
+            Gdk.EventMask.BUTTON_RELEASE_MASK |
+            Gdk.EventMask.BUTTON1_MOTION_MASK |
+            Gdk.EventMask.POINTER_MOTION_MASK |
+            Gdk.EventMask.POINTER_MOTION_HINT_MASK |
+            Gdk.EventMask.BUTTON_PRESS_MASK |
+            Gdk.EventMask.KEY_PRESS_MASK |
+            Gdk.EventMask.KEY_RELEASE_MASK |
+            Gdk.EventMask.EXPOSURE_MASK
         )
 
         self.notice_mouse = False

--- a/fract4dgui/gtkfractal.py
+++ b/fract4dgui/gtkfractal.py
@@ -463,14 +463,14 @@ class T(Hidden):
 
         drawing_area = Gtk.DrawingArea()
         drawing_area.set_events(
-            Gdk.EventMask.BUTTON_RELEASE_MASK |
-            Gdk.EventMask.BUTTON1_MOTION_MASK |
-            Gdk.EventMask.POINTER_MOTION_MASK |
-            Gdk.EventMask.POINTER_MOTION_HINT_MASK |
-            Gdk.EventMask.BUTTON_PRESS_MASK |
-            Gdk.EventMask.KEY_PRESS_MASK |
-            Gdk.EventMask.KEY_RELEASE_MASK |
-            Gdk.EventMask.EXPOSURE_MASK
+            Gdk.EventMask.BUTTON_RELEASE_MASK
+            | Gdk.EventMask.BUTTON1_MOTION_MASK
+            | Gdk.EventMask.POINTER_MOTION_MASK
+            | Gdk.EventMask.POINTER_MOTION_HINT_MASK
+            | Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.KEY_PRESS_MASK
+            | Gdk.EventMask.KEY_RELEASE_MASK
+            | Gdk.EventMask.EXPOSURE_MASK
         )
 
         self.notice_mouse = False
@@ -507,7 +507,7 @@ class T(Hidden):
             try:
                 GLib.idle_add(
                     form.set_param, order, entry.get_text())
-            except Exception as err:
+            except Exception:
                 # FIXME: produces too many errors
                 msg = "Invalid value '%s': must be a number" % \
                       entry.get_text()
@@ -547,10 +547,9 @@ class T(Hidden):
 
             adj.connect('value-changed', adj_changed, form, order)
 
-            hscale = Gtk.Scale.new(Gtk.Orientation.HORIZONTAL, adj)
-            hscale.set_draw_value(False)
+            hscale = Gtk.Scale(adjustment=adj, draw_value=False)
             hscale.update_function = set_adj
-            vbox = Gtk.VBox()
+            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
             vbox.pack_start(widget, True, True, 0)
             vbox.pack_start(hscale, True, True, 0)
             return vbox
@@ -586,7 +585,6 @@ class T(Hidden):
             except Exception as err:
                 msg = "error setting bool param: %s" % str(err)
                 print(msg)
-                #GLib.idle_add(f.warn, msg)
 
             return False
 
@@ -761,7 +759,7 @@ class T(Hidden):
             try:
                 selected_func_name = form.get_func_value(name)
                 index = funclist.index(selected_func_name)
-            except ValueError as err:
+            except ValueError:
                 # func.cname not in list
                 # print "bad cname"
                 return
@@ -805,7 +803,7 @@ class T(Hidden):
                 try:
                     i = int(widget.get_text())
                     self.set_maxiter(i)
-                except ValueError as err:
+                except ValueError:
                     msg = "Invalid value '%s': must be a number" % \
                           widget.get_text()
                     GLib.idle_add(self.warn, msg)
@@ -932,8 +930,7 @@ class T(Hidden):
 
     def get_paint_color(self):
         color = self.paint_color_sel.get_current_color()
-        return (color.red / 65535.0, color.green /
-                65535.0, color.blue / 65535.0)
+        return (color.red / 65535.0, color.green / 65535.0, color.blue / 65535.0)
 
     def onPaint(self, x, y):
         # obtain index
@@ -1029,7 +1026,7 @@ class T(Hidden):
 
         try:
             buf = self.image.image_buffer(x, y)
-        except MemoryError as err:
+        except MemoryError:
             # suppress these errors
             return
 

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -471,7 +471,6 @@ class MainWindow(Actions, ApplicationWindow):
         if text is None:
             return
 
-        #print("paste! %s" % text)
         grad = self.f.get_gradient()
         grad.load_from_url(text)
         self.f.set_gradient(grad)

--- a/fract4dgui/painter.py
+++ b/fract4dgui/painter.py
@@ -7,7 +7,6 @@ from . import dialog
 
 class PainterDialog(dialog.T):
     def __init__(self, main_window):
-        # pylint: disable=no-member
         dialog.T.__init__(
             self,
             _("Painter"),

--- a/fract4dgui/preferences.py
+++ b/fract4dgui/preferences.py
@@ -64,7 +64,6 @@ GObject.type_register(Preferences)
 
 class PrefsDialog(dialog.T):
     def __init__(self, main_window, f, userPrefs):
-        # pylint: disable=no-member
         dialog.T.__init__(
             self,
             _("Gnofract 4D Preferences"),
@@ -399,7 +398,7 @@ class PrefsDialog(dialog.T):
         table.attach(hlabel, 0, 1, 1, 1)
 
         self.fix_ratio = Gtk.CheckButton(
-            label="Maintain Aspect _Ratio", 
+            label="Maintain Aspect _Ratio",
             tooltip_text="Keep the image rectangle the same shape when changing its size",
             use_underline=True,
             active=True)

--- a/fract4dgui/renderqueue.py
+++ b/fract4dgui/renderqueue.py
@@ -1,8 +1,6 @@
 # A module which manages a queue of images to render in the background
 # and a UI for the same
 
-# pylint: disable=no-member
-
 import copy
 
 from gi.repository import Gtk, GObject
@@ -110,18 +108,16 @@ class QueueDialog(dialog.T):
             float  # % complete
         )
 
-        self.view = Gtk.TreeView.new_with_model(self.store)
-        column = Gtk.TreeViewColumn(
-            _('_Name'), Gtk.CellRendererText(), text=0)
-        self.view.append_column(column)
-        column = Gtk.TreeViewColumn(
-            _('_Size'), Gtk.CellRendererText(), text=1)
-        self.view.append_column(column)
-        column = Gtk.TreeViewColumn(
-            _('_Progress'), CellRendererProgress(), value=2)
-        self.view.append_column(column)
+        view = Gtk.TreeView(model=self.store)
+        view.append_column(Gtk.TreeViewColumn(
+            _('_Name'), Gtk.CellRendererText(), text=0))
+        view.append_column(Gtk.TreeViewColumn(
+            _('_Size'), Gtk.CellRendererText(), text=1))
+        view.append_column(Gtk.TreeViewColumn(
+            _('_Progress'), CellRendererProgress(), value=2))
 
-        self.vbox.add(self.view)
+        self.vbox.add(view)
+        self.vbox.show_all()
 
     def onQueueChanged(self, q):
         self.store.clear()
@@ -135,7 +131,3 @@ class QueueDialog(dialog.T):
 
     def onQueueDone(self, q):
         self.hide()
-
-    def show(self):
-        Gtk.Dialog.show(self)
-        self.vbox.show_all()

--- a/fract4dgui/settings.py
+++ b/fract4dgui/settings.py
@@ -11,15 +11,13 @@ from . import hig, browser, utils, browser_model
 
 class SettingsPane(Gtk.Box):
     def __init__(self, main_window, f):
-        Gtk.Box.__init__(self)
-        self.set_orientation(Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self.main_window = main_window
         self.f = f
 
         label_box = self.make_label_box(_("Fractal Settings"))
-        self.notebook = Gtk.Notebook()
-        self.notebook.set_name("settings_notebook")
+        self.notebook = Gtk.Notebook(name="settings_notebook")
         self.pack_start(label_box, False, False, 0)
         self.pack_start(self.notebook, True, True, 0)
 
@@ -37,9 +35,8 @@ class SettingsPane(Gtk.Box):
         self.notebook.show_all()
 
     def make_label_box(self, title):
-        label_box = Gtk.HBox(name="dialog_label_box")
-        label = Gtk.Label(label=title)
-        label_box.pack_start(label, False, False, 0)
+        label_box = Gtk.Box(name="dialog_label_box")
+        label_box.pack_start(Gtk.Label(label=title), False, False, 0)
         close = Gtk.Button(label=_("Close"))
         label_box.pack_end(close, False, False, 0)
         label_box.show_all()
@@ -139,7 +136,7 @@ class SettingsPane(Gtk.Box):
             self.f.get_gradient().is_coolorable())
 
     def create_colors_table(self):
-        gradbox = Gtk.VBox()
+        gradbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         browse_button = Gtk.Button(label=_("Browse..."))
         browse_button.connect(
@@ -150,18 +147,17 @@ class SettingsPane(Gtk.Box):
         # gradient viewer
         self.grad_handle_height = 8
 
-        self.gradarea = Gtk.DrawingArea()
+        self.gradarea = Gtk.DrawingArea(width_request=256, height_request=96)
 
         self.gradarea.add_events(
-            Gdk.EventMask.BUTTON_RELEASE_MASK |
-            Gdk.EventMask.BUTTON1_MOTION_MASK |
-            Gdk.EventMask.POINTER_MOTION_HINT_MASK |
-            Gdk.EventMask.BUTTON_PRESS_MASK |
-            Gdk.EventMask.KEY_PRESS_MASK |
-            Gdk.EventMask.KEY_RELEASE_MASK
+            Gdk.EventMask.BUTTON_RELEASE_MASK
+            | Gdk.EventMask.BUTTON1_MOTION_MASK
+            | Gdk.EventMask.POINTER_MOTION_HINT_MASK
+            | Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.KEY_PRESS_MASK
+            | Gdk.EventMask.KEY_RELEASE_MASK
         )
 
-        self.gradarea.set_size_request(256, 96)
         self.gradarea.connect('draw', self.redraw_rect)
         self.gradarea.connect('button-press-event', self.gradarea_mousedown)
         self.gradarea.connect('button-release-event', self.gradarea_clicked)
@@ -170,11 +166,11 @@ class SettingsPane(Gtk.Box):
         self.f.connect('parameters-changed', self.redraw)
         gradbox.pack_start(self.gradarea, False, False, 1)
 
-        table = Gtk.Grid()
-        table.set_column_homogeneous(True)
-        table.set_row_spacing(50)
-        table.set_column_spacing(10)
-        table.set_margin_top(30)
+        table = Gtk.Grid(
+            column_homogeneous=True,
+            column_spacing=10,
+            row_spacing=50,
+            margin_top=30)
 
         grad = self.f.get_gradient()
         self.left_color_button = utils.ColorButton(
@@ -307,20 +303,17 @@ class SettingsPane(Gtk.Box):
 
     def create_colors_page(self):
         table = self.create_colors_table()
-        label = Gtk.Label(label=_("_Colors"))
-        label.set_use_underline(True)
+        label = Gtk.Label(label=_("_Colors"), use_underline=True)
         self.notebook.append_page(table, label)
         self.select_segment(-1)
 
     def create_location_page(self):
         table = self.create_location_table()
-        label = Gtk.Label(label=_("_Location"))
-        label.set_use_underline(True)
+        label = Gtk.Label(label=_("_Location"), use_underline=True)
         self.notebook.append_page(table, label)
 
     def create_location_table(self):
-        table = Gtk.Grid()
-        table.set_row_spacing(5)
+        table = Gtk.Grid(row_spacing=5)
         self.create_param_entry(table, 0, _("_X :"), self.f.XCENTER)
         self.create_param_entry(table, 1, _("_Y :"), self.f.YCENTER)
         self.create_param_entry(table, 2, _("_Z :"), self.f.ZCENTER)
@@ -336,24 +329,17 @@ class SettingsPane(Gtk.Box):
         return table
 
     def create_general_page(self):
-        table = Gtk.Grid()
-        table.set_column_spacing(5)
-        table.set_row_spacing(5)
-        label = Gtk.Label(label=_("_General"))
-        label.set_use_underline(True)
+        table = Gtk.Grid(column_spacing=5, row_spacing=5)
+        label = Gtk.Label(label=_("_General"), use_underline=True)
         self.notebook.append_page(table, label)
         table.attach(self.create_yflip_widget(), 0, 0, 2, 1)
         table.attach(self.create_periodicity_widget(), 0, 1, 2, 1)
         self.create_tolerance_entry(table, 2, _("_Tolerance"))
 
     def create_tolerance_entry(self, table, row, text):
-        label = Gtk.Label(label=text)
-        label.set_use_underline(True)
+        entry = Gtk.Entry(activates_default=True)
+        label = Gtk.Label(label=text, mnemonic_widget=entry, use_underline=True)
         table.attach(label, 0, row, 1, 1)
-
-        entry = Gtk.Entry()
-        entry.set_activates_default(True)
-        label.set_mnemonic_widget(entry)
         table.attach(entry, 1, row, 1, 1)
 
         def set_entry(f, *args):
@@ -362,7 +348,7 @@ class SettingsPane(Gtk.Box):
                 if current != f.period_tolerance:
                     # print "update entry to %.17f" % f.period_tolerance
                     entry.set_text("%.17f" % f.period_tolerance)
-            except ValueError as err:
+            except ValueError:
                 # current was set to something that isn't a float
                 entry.set_text("%.17f" % f.period_tolerance)
 
@@ -379,10 +365,11 @@ class SettingsPane(Gtk.Box):
         entry.connect('focus-out-event', set_fractal)
 
     def create_yflip_widget(self):
-        widget = Gtk.CheckButton(label=_("Flip Y Axis"))
-        widget.set_use_underline(True)
-        widget.set_tooltip_text(
-            _("If set, Y axis increases down the screen, otherwise up the screen"))
+        widget = Gtk.CheckButton(
+            label=_("Flip Y Axis"),
+            use_underline=True,
+            tooltip_text=_("If set, Y axis increases down the screen,"
+                           " otherwise up the screen"))
 
         def set_widget(*args):
             widget.set_active(self.f.yflip)
@@ -397,10 +384,11 @@ class SettingsPane(Gtk.Box):
         return widget
 
     def create_periodicity_widget(self):
-        widget = Gtk.CheckButton(label=_("Periodicity Checking"))
-        widget.set_use_underline(True)
-        widget.set_tooltip_text(
-            _("Try to speed up calculations by looking for loops. Can cause incorrect images with some functions, though."))
+        widget = Gtk.CheckButton(
+            label=_("Periodicity Checking"),
+            use_underline=True,
+            tooltip_text=_("Try to speed up calculations by looking for loops."
+                           " Can cause incorrect images with some functions, though."))
 
         def set_widget(*args):
             widget.set_active(self.f.periodicity)
@@ -415,10 +403,8 @@ class SettingsPane(Gtk.Box):
         return widget
 
     def add_notebook_page(self, page, text):
-        label = Gtk.Label(label=text)
-        label.set_use_underline(True)
-        frame = Gtk.Frame()
-        frame.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        label = Gtk.Label(label=text, use_underline=True)
+        frame = Gtk.Frame(shadow_type=Gtk.ShadowType.ETCHED_IN)
         frame.add(page)
         self.notebook.append_page(frame, label)
 
@@ -429,10 +415,8 @@ class SettingsPane(Gtk.Box):
         self.f.remove_transform(self.selected_transform)
 
     def create_transforms_page(self):
-        vbox = Gtk.VBox()
-        table = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-        table.set_spacing(10)
-        table.set_property("margin", 10)
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        table = Gtk.Box(spacing=10, margin=10)
         vbox.pack_start(table, False, False, 0)
 
         self.transform_store = Gtk.ListStore(str, object)
@@ -446,29 +430,27 @@ class SettingsPane(Gtk.Box):
 
         self.f.connect('formula-changed', set_store)
 
-        self.transform_view = Gtk.TreeView(model=self.transform_store)
-        self.transform_view.set_headers_visible(False)
-        self.transform_view.set_size_request(150, 250)
-        renderer = Gtk.CellRendererText()
-        column = Gtk.TreeViewColumn('_Transforms', renderer, text=0)
-
+        self.transform_view = Gtk.TreeView(
+            model=self.transform_store,
+            headers_visible=False,
+            width_request=150,
+            height_request=250)
+        column = Gtk.TreeViewColumn('_Transforms', Gtk.CellRendererText(), text=0)
         self.transform_view.append_column(column)
 
-        sw = Gtk.ScrolledWindow()
-        sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        sw = Gtk.ScrolledWindow(shadow_type=Gtk.ShadowType.IN, min_content_height=200)
         sw.add(self.transform_view)
-        sw.set_shadow_type(Gtk.ShadowType.IN)
-        sw.set_min_content_height(200)
         table.pack_start(sw, True, True, 0)
 
-        add_button = Gtk.Button.new_with_label("Add")
+        add_button = Gtk.Button(label="Add")
         add_button.connect(
             'clicked', self.show_browser, browser_model.TRANSFORM)
-        remove_button = Gtk.Button.new_with_label("Remove")
+        remove_button = Gtk.Button(label="Remove")
         remove_button.connect(
             'clicked', self.remove_transform)
-        buttonbox = Gtk.ButtonBox(orientation=Gtk.Orientation.VERTICAL)
-        buttonbox.set_layout(Gtk.ButtonBoxStyle.SPREAD)
+        buttonbox = Gtk.ButtonBox(
+            orientation=Gtk.Orientation.VERTICAL,
+            layout_style=Gtk.ButtonBoxStyle.SPREAD)
         buttonbox.add(add_button)
         buttonbox.add(remove_button)
         table.pack_start(buttonbox, False, False, 0)
@@ -500,22 +482,20 @@ class SettingsPane(Gtk.Box):
         self.update_transform_parameters(parent)
 
     def create_browsable_name(self, table, param_type, typename, tip):
-        label = Gtk.Label(label=self.f.forms[param_type].funcName)
-        label.set_hexpand(True)
+        label = Gtk.Label(label=self.f.forms[param_type].funcName, hexpand=True)
 
         def set_label(*args):
             label.set_text(self.f.forms[param_type].funcName)
 
         self.f.connect('parameters-changed', set_label)
 
-        button = Gtk.Button(label=_("_Browse..."))
-        button.set_use_underline(True)
-        button.set_tooltip_text(tip)
+        button = Gtk.Button(
+            label=_("_Browse..."),
+            use_underline=True,
+            tooltip_text=tip)
         button.connect('clicked', self.show_browser, param_type)
 
-        typelabel = Gtk.Label(label=typename)
-        typelabel.set_halign(Gtk.Align.END)
-        typelabel.set_valign(Gtk.Align.CENTER)
+        typelabel = Gtk.Label(label=typename, halign=Gtk.Align.END, valign=Gtk.Align.CENTER)
 
         table.attach(typelabel, 0, 0, 1, 1)
         table.attach(label, 1, 0, 1, 1)
@@ -566,13 +546,8 @@ class SettingsPane(Gtk.Box):
         d.destroy()
 
     def create_formula_text_area(self, parent, formindex, formtype):
-        sw = Gtk.ScrolledWindow()
-        sw.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
-        sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        sw.set_min_content_height(400)
-
+        sw = Gtk.ScrolledWindow(shadow_type=Gtk.ShadowType.ETCHED_IN, min_content_height=400)
         textview = Gtk.TextView()
-
         sw.add(textview)
         parent.pack_start(sw, True, True, 2)
 
@@ -591,8 +566,8 @@ class SettingsPane(Gtk.Box):
         self.update_formula_text(self.f, textview, formindex)
 
     def create_formula_parameters_page(self):
-        vbox = Gtk.VBox()
-        formbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        formbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.create_formula_widget_table(
             formbox,
             0,
@@ -601,14 +576,13 @@ class SettingsPane(Gtk.Box):
 
         vbox.pack_start(formbox, False, False, 0)
         self.create_formula_text_area(vbox, 0, FormulaTypes.FRACTAL)
-        sw = Gtk.ScrolledWindow.new(None, None)
-        sw.set_overlay_scrolling(False)
+        sw = Gtk.ScrolledWindow(overlay_scrolling=False)
         sw.add(vbox)
         self.add_notebook_page(sw, _("Formula"))
 
     def create_outer_page(self):
-        vbox = Gtk.VBox()
-        formbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        formbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.create_formula_widget_table(
             formbox,
             1,
@@ -617,14 +591,13 @@ class SettingsPane(Gtk.Box):
 
         vbox.pack_start(formbox, False, False, 0)
         self.create_formula_text_area(vbox, 1, FormulaTypes.COLORFUNC)
-        sw = Gtk.ScrolledWindow.new(None, None)
-        sw.set_overlay_scrolling(False)
+        sw = Gtk.ScrolledWindow(overlay_scrolling=False)
         sw.add(vbox)
         self.add_notebook_page(sw, _("Outer"))
 
     def create_inner_page(self):
-        vbox = Gtk.VBox()
-        formbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        formbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.create_formula_widget_table(
             formbox,
             2,
@@ -633,8 +606,7 @@ class SettingsPane(Gtk.Box):
 
         vbox.pack_start(formbox, False, False, 0)
         self.create_formula_text_area(vbox, 2, FormulaTypes.COLORFUNC)
-        sw = Gtk.ScrolledWindow.new(None, None)
-        sw.set_overlay_scrolling(False)
+        sw = Gtk.ScrolledWindow(overlay_scrolling=False)
         sw.add(vbox)
         self.add_notebook_page(sw, _("Inner"))
 
@@ -647,8 +619,7 @@ class SettingsPane(Gtk.Box):
                 pass
 
         if self.selected_transform is not None:
-            self.tables[3] = Gtk.Grid()
-            self.tables[3].set_column_spacing(10)
+            self.tables[3] = Gtk.Grid(column_spacing=10)
             self.f.populate_formula_settings(
                 self.tables[3],
                 self.selected_transform + 3)
@@ -677,9 +648,7 @@ class SettingsPane(Gtk.Box):
                 except AttributeError:
                     pass
 
-            table = Gtk.Grid()
-            table.set_row_spacing(5)
-            table.set_column_spacing(10)
+            table = Gtk.Grid(row_spacing=5, column_spacing=10)
             self.create_browsable_name(table, param_type, typename, tip)
 
             self.f.populate_formula_settings(
@@ -724,15 +693,10 @@ class SettingsPane(Gtk.Box):
         dialog.destroy()
 
     def create_param_entry(self, table, row, text, param):
-        label = Gtk.Label(label=text)
-        label.set_use_underline(True)
-
-        label.set_justify(Gtk.Justification.RIGHT)
+        label = Gtk.Label(label=text, use_underline=True, justify=Gtk.Justification.RIGHT)
         table.attach(label, 0, row, 1, 1)
 
-        entry = Gtk.Entry()
-        entry.set_activates_default(True)
-        entry.set_hexpand(True)
+        entry = Gtk.Entry(activates_default=True, hexpand=True)
         table.attach(entry, 1, row, 1, 1)
         label.set_mnemonic_widget(entry)
 
@@ -741,7 +705,7 @@ class SettingsPane(Gtk.Box):
                 current = float(entry.get_text())
                 if current != f.get_param(param):
                     entry.set_text("%.17f" % f.get_param(param))
-            except ValueError as err:
+            except ValueError:
                 # current was set to something that isn't a float
                 entry.set_text("%.17f" % f.get_param(param))
 

--- a/fract4dgui/settings.py
+++ b/fract4dgui/settings.py
@@ -150,12 +150,12 @@ class SettingsPane(Gtk.Box):
         self.gradarea = Gtk.DrawingArea(width_request=256, height_request=96)
 
         self.gradarea.add_events(
-            Gdk.EventMask.BUTTON_RELEASE_MASK
-            | Gdk.EventMask.BUTTON1_MOTION_MASK
-            | Gdk.EventMask.POINTER_MOTION_HINT_MASK
-            | Gdk.EventMask.BUTTON_PRESS_MASK
-            | Gdk.EventMask.KEY_PRESS_MASK
-            | Gdk.EventMask.KEY_RELEASE_MASK
+            Gdk.EventMask.BUTTON_RELEASE_MASK |
+            Gdk.EventMask.BUTTON1_MOTION_MASK |
+            Gdk.EventMask.POINTER_MOTION_HINT_MASK |
+            Gdk.EventMask.BUTTON_PRESS_MASK |
+            Gdk.EventMask.KEY_PRESS_MASK |
+            Gdk.EventMask.KEY_RELEASE_MASK
         )
 
         self.gradarea.connect('draw', self.redraw_rect)

--- a/fract4dgui/tests/test_DlgAdvOpt.py
+++ b/fract4dgui/tests/test_DlgAdvOpt.py
@@ -17,7 +17,7 @@ class Test(testgui.TestCase):
 
     @patch("gi.repository.Gtk.Dialog.run")
     def testDlgAdvOptions(self, mock_dialog_run):
-        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.OK
+        mock_dialog_run.side_effect = lambda: Gtk.ResponseType.OK
 
         parent = Gtk.Window()
         self.test_animation.add_keyframe(

--- a/fract4dgui/tests/test_autozoom.py
+++ b/fract4dgui/tests/test_autozoom.py
@@ -16,7 +16,7 @@ class Test(testgui.TestCase):
 
     @patch("gi.repository.Gtk.Dialog.run")
     def testAutozoom(self, mock_dialog_run):
-        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.CLOSE
+        mock_dialog_run.side_effect = lambda: Gtk.ResponseType.CLOSE
 
         azd = autozoom.AutozoomDialog(self.mw, self.f)
         self.assertEqual(azd.minsize_entry.get_text(), "1e-13")

--- a/fract4dgui/tests/test_browser_model.py
+++ b/fract4dgui/tests/test_browser_model.py
@@ -36,7 +36,7 @@ class Test(testbase.ClassSetup):
         cls.g_comp.load_formula_file("gf4d.uxf")
 
     def testCreation(self):
-        bm = browser_model.T(Test.g_comp)
+        browser_model.T(Test.g_comp)
 
     def testFuncMapping(self):
         bm = browser_model.T(Test.g_comp)
@@ -114,10 +114,10 @@ class Test(testbase.ClassSetup):
         bm.set_type(browser_model.FRACTAL)
         self.assertRaises(IOError, bm.set_file, "nonexistent.frm")
 
-    def assertListSorted(self, l):
+    def assertListSorted(self, sorted_list):
         last = ""
-        for f in l:
-            self.assertTrue(last < f.lower(), "list not sorted: %s" % l)
+        for f in sorted_list:
+            self.assertTrue(last < f.lower(), f"list not sorted: {sorted_list}")
             last = f.lower()
 
     def testFormulasSorted(self):

--- a/fract4dgui/tests/test_director.py
+++ b/fract4dgui/tests/test_director.py
@@ -75,17 +75,17 @@ class Test(testgui.TestCase):
     @patch("gi.repository.Gtk.FileChooserDialog.get_filename")
     def testFileChoosers(self, mock_dialog_get_filename, mock_dialog_run):
         filename = "test_file"
-        mock_dialog_get_filename.side_effect = lambda : filename
+        mock_dialog_get_filename.side_effect = lambda: filename
 
         dd = director.DirectorDialog(self.parent)
 
-        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.OK
+        mock_dialog_run.side_effect = lambda: Gtk.ResponseType.OK
         self.assertEqual(dd.get_fct_file(), filename)
         self.assertEqual(dd.get_avi_file(), filename)
         self.assertEqual(dd.get_cfg_file_save(), filename)
         self.assertEqual(dd.get_cfg_file_open(), filename)
 
-        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.CANCEL
+        mock_dialog_run.side_effect = lambda: Gtk.ResponseType.CANCEL
         self.assertEqual(dd.get_fct_file(), "")
         self.assertEqual(dd.get_avi_file(), "")
         self.assertEqual(dd.get_cfg_file_save(), "")
@@ -141,8 +141,9 @@ class Test(testgui.TestCase):
 
         self.assertRaisesMessage(
             director.SanityCheckError,
-            "Keyframe {} is in the temporary .fct directory and could be overwritten. Please change temp directory.".format(
-                os.path.join(Test.tmpdir.name, "director2.fct")),
+            f"Keyframe {os.path.join(Test.tmpdir.name, 'director2.fct')} is in"
+            " the temporary .fct directory and could be overwritten."
+            " Please change temp directory.",
             dd.check_sanity)
 
     def testKeyframeClash(self):
@@ -152,10 +153,14 @@ class Test(testgui.TestCase):
 
         self.assertRaises(
             director.SanityCheckError,
-            dd.check_for_keyframe_clash, os.path.join(Test.tmpdir.name, "foo.fct"), Test.tmpdir.name)
+            dd.check_for_keyframe_clash,
+            os.path.join(Test.tmpdir.name, "foo.fct"),
+            Test.tmpdir.name)
         self.assertRaises(
             director.SanityCheckError,
-            dd.check_for_keyframe_clash, os.path.join(Test.tmpdir.name, "foo.fct"), Test.tmpdir.name)
+            dd.check_for_keyframe_clash,
+            os.path.join(Test.tmpdir.name, "foo.fct"),
+            Test.tmpdir.name)
 
     def testPNGGen(self):
         dd = director.DirectorDialog(self.parent)

--- a/fract4dgui/tests/test_director_prefs.py
+++ b/fract4dgui/tests/test_director_prefs.py
@@ -27,13 +27,13 @@ class Test(testgui.TestCase):
     @patch("gi.repository.Gtk.FileChooserDialog.get_filename")
     def testGetFolder(self, mock_dialog_get_filename, mock_dialog_run):
         filename = "test_file"
-        mock_dialog_get_filename.side_effect = lambda : filename
+        mock_dialog_get_filename.side_effect = lambda: filename
 
         parent = Gtk.Window()
         dp = director_prefs.DirectorPrefs(self.test_animation, parent)
 
-        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.OK
+        mock_dialog_run.side_effect = lambda: Gtk.ResponseType.OK
         self.assertEqual(dp.get_folder(), filename)
 
-        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.CANCEL
+        mock_dialog_run.side_effect = lambda: Gtk.ResponseType.CANCEL
         self.assertEqual(dp.get_folder(), "")

--- a/fract4dgui/tests/test_hig.py
+++ b/fract4dgui/tests/test_hig.py
@@ -82,7 +82,8 @@ class Test(unittest.TestCase):
         d = hig.ConfirmationAlert(
             transient_for=toplevel,
             primary="Convert sub-meson structure?",
-            secondary="The process is agonizingly painful and could result in permanent damage to the space-time continuum",
+            secondary="The process is agonizingly painful and could result"
+                      " in permanent damage to the space-time continuum",
             proceed_button="Convert",
             alternate_button="Go Fishing")
 

--- a/fract4dgui/tests/test_main_window.py
+++ b/fract4dgui/tests/test_main_window.py
@@ -32,6 +32,7 @@ class Application(Gtk.Application):
     def get_menu_by_id(self, menuid):
         return self.menu_builder.get_object(menuid)
 
+
 class WrapMainWindow(main_window.MainWindow):
     def __init__(self, config):
         self.errors = []
@@ -156,7 +157,7 @@ class Test(testgui.TestCase):
 
     @patch("gi.repository.Gtk.Dialog.run")
     def testAbout(self, mock_dialog_run):
-        mock_dialog_run.side_effect = lambda : Gtk.ResponseType.OK
+        mock_dialog_run.side_effect = lambda: Gtk.ResponseType.OK
 
         self.mw.about()
 
@@ -223,7 +224,8 @@ class Test(testgui.TestCase):
             fractal.T.DEFAULT_FORMULA_FILE = old_default
 
     def testToggleFullScreen(self):
-        action = Gio.SimpleAction.new_stateful("ViewFullScreenAction", None, GLib.Variant("b", False))
+        action = Gio.SimpleAction.new_stateful(
+            "ViewFullScreenAction", None, GLib.Variant("b", False))
         self.mw.toggle_full_screen(action, None)
         self.assertTrue(self.mw.fullscreen_action.get_state().unpack())
         action.set_state(GLib.Variant("b", True))

--- a/fract4dgui/toolbar.py
+++ b/fract4dgui/toolbar.py
@@ -5,7 +5,7 @@ from gi.repository import Gtk
 
 class T(Gtk.Box):
     def __init__(self):
-        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, margin=5, spacing=1)
+        super().__init__(margin=5, spacing=1)
 
     @staticmethod
     def button_args(icon_name, tip_text, action):

--- a/fract4dgui/utils.py
+++ b/fract4dgui/utils.py
@@ -1,11 +1,4 @@
-# This file contains utility classes and functions used by the GUI
-# Many of them 'cover up' differences between pygtk versions - these
-# follow the general pattern
-#
-# try:
-#    do new thing
-# except:
-#    fall back to the 'old way'
+# This file contains utility classes and functions used across the GUI
 
 import os
 


### PR DESCRIPTION
This works through the fract4dgui folder:
* using keyword arguments with Gtk constructors where possible
* replacing deprecated Gtk.Hbox and Gtk.Vbox
* converting instance variables to local variables where possible
* removing `pylint: disable=no-member` where possible
* enabling the whole folder to pass all flake8 tests (except E402 for files with `gi.require_`)
