### PR TITLE
Prevent user drawing selection on the preview

### DIFF
--- a/fract4dgui/gtkfractal.py
+++ b/fract4dgui/gtkfractal.py
@@ -1058,6 +1058,9 @@ class Preview(T):
     def onButtonRelease(self, widget, event):
         pass
 
+    def onMotionNotify(self, widget, event):
+        pass
+
     def error(self, msg, exn):
         # suppress errors from previews
         pass


### PR DESCRIPTION
Has no effect and cannot be cleared.

---

Don't expect many people try using the mouse on the preview image, but just in case.
