### PR TITLE
Angle tweaks

### DIFF
--- a/fract4dgui/angle.py
+++ b/fract4dgui/angle.py
@@ -17,7 +17,8 @@ class T(Gtk.DrawingArea):
     two_pi = 2.0 * math.pi
     ptr_radius = 4
 
-    def __init__(self, text, tip):
+    def __init__(self, text, tip, axis):
+        self.axis = axis
         self.radius = 0
         self.text = text
 

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -349,7 +349,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         self.toolbar.add(self.warpmenu)
 
-    def create_angle_widget(self, name, tip, axis, is4dsensitive):
+    def add_angle(self, name, tip, axis, is4dsensitive):
         my_angle = angle.T(name, tip, axis)
         my_angle.connect('value-slightly-changed',
                          self.on_angle_slightly_changed)
@@ -425,22 +425,22 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         # angles
         self.toolbar.add_space()
 
-        self.create_angle_widget(
+        self.add_angle(
             _("xy"), _("Angle in the XY plane"), fractal.T.XYANGLE, False)
 
-        self.create_angle_widget(
+        self.add_angle(
             _("xz"), _("Angle in the XZ plane"), fractal.T.XZANGLE, True)
 
-        self.create_angle_widget(
+        self.add_angle(
             _("xw"), _("Angle in the XW plane"), fractal.T.XWANGLE, True)
 
-        self.create_angle_widget(
+        self.add_angle(
             _("yz"), _("Angle in the YZ plane"), fractal.T.YZANGLE, True)
 
-        self.create_angle_widget(
+        self.add_angle(
             _("yw"), _("Angle in the YW plane"), fractal.T.YWANGLE, True)
 
-        self.create_angle_widget(
+        self.add_angle(
             _("zw"), _("Angle in the ZW plane"), fractal.T.ZWANGLE, True)
 
         # fourways

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -320,10 +320,8 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.panes.pack2(self.settingsPane, resize=False, shrink=False)
 
     def add_fourway(self, name, tip, axis, is4dsensitive):
-        my_fourway = fourway.T(name, tip)
+        my_fourway = fourway.T(name, tip, axis)
         self.toolbar.add(my_fourway)
-
-        my_fourway.axis = axis
 
         my_fourway.connect('value-slightly-changed', self.on_drag_fourway)
         my_fourway.connect('value-changed', self.on_release_fourway)
@@ -352,7 +350,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.toolbar.add(self.warpmenu)
 
     def create_angle_widget(self, name, tip, axis, is4dsensitive):
-        my_angle = angle.T(name, tip)
+        my_angle = angle.T(name, tip, axis)
         my_angle.connect('value-slightly-changed',
                          self.on_angle_slightly_changed)
         my_angle.connect('value-changed',
@@ -360,8 +358,6 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         self.f.connect('parameters-changed',
                        self.update_angle_widget, my_angle)
-
-        my_angle.axis = axis
 
         self.toolbar.add(my_angle)
 

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -13,7 +13,8 @@ class T(Gtk.DrawingArea):
             None, (GObject.TYPE_INT, GObject.TYPE_INT))
     }
 
-    def __init__(self, text, tip):
+    def __init__(self, text, tip, axis=None):
+        self.axis = axis
         self.button = 0
         self.radius = 0
         self.last_x = 0

--- a/fract4dgui/tests/test_angle.py
+++ b/fract4dgui/tests/test_angle.py
@@ -5,6 +5,9 @@
 import math
 import unittest
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 from fract4dgui import angle
 
 

--- a/fract4dgui/tests/test_angle.py
+++ b/fract4dgui/tests/test_angle.py
@@ -13,14 +13,14 @@ from fract4dgui import angle
 
 class Test(unittest.TestCase):
     def testCreate(self):
-        a = angle.T("hello", "angle")
+        a = angle.T("hello", "angle", 0)
         self.assertTrue(a)
         self.assertEqual(a.adjustment.get_lower(), -math.pi)
         self.assertEqual(a.adjustment.get_upper(), math.pi)
         self.assertEqual(a.adjustment.get_value(), 0.0)
 
     def testAngles(self):
-        a = angle.T("foo", "angle")
+        a = angle.T("foo", "angle", 0)
 
         self.assertEqual(a.get_current_angle(), 0.0)
 
@@ -31,7 +31,7 @@ class Test(unittest.TestCase):
         self.assertEqual(a.get_current_angle(), math.pi)
 
     def testPointerCoords(self):
-        a = angle.T("foo", "angle")
+        a = angle.T("foo", "angle", 0)
 
         # 0 should point right
         self.assertNearlyEqual(
@@ -59,7 +59,7 @@ class Test(unittest.TestCase):
             (0, -(40 - angle.T.ptr_radius)))
 
     def testUpdateFromMouse(self):
-        a = angle.T("foo", "angle")
+        a = angle.T("foo", "angle", 0)
         a.update_from_mouse(100, 100)
 
     def assertNearlyEqual(self, a, b):


### PR DESCRIPTION
A few minor tweaks around angles:
* test_angle doesn't import testgui so does need a gi.require_version() (for angle.py)
* declare axis in the angle and fourway classes
* rename ApplicationWindow.create_angle_widget(), to be consistent with add_fourway(), and add_warpmenu(), that both create the object and add it to the toolbar.
