### PR TITLE
Create HiresImageSaveChooser and Rename statusbar

### DIFF
--- a/fract4dgui/application_widgets.py
+++ b/fract4dgui/application_widgets.py
@@ -46,6 +46,24 @@ class Fract4dOpenChooser(utils.FileOpenChooser):
         self.set_filter(all_filter)
 
 
+class HiresImageSaveChooser(utils.FileSaveChooser):
+    def __init__(self, parent, file_matches):
+        super().__init__(
+            _("Save High Resolution Image"), parent, file_matches)
+
+        table = Gtk.Grid(row_spacing=1, column_spacing=1)
+        self.width = Gtk.Entry(text="2048")
+        self.height = Gtk.Entry(text="1536")
+        table.attach(Gtk.Label(label=_("Width:")), 0, 0, 1, 1)
+        table.attach(Gtk.Label(label=_("Height:")), 0, 1, 1, 1)
+        table.attach(self.width, 1, 0, 1, 1)
+        table.attach(self.height, 1, 1, 1, 1)
+        self.set_extra_widget(table)
+
+    def get_hires_dimensions(self):
+        return int(self.width.get_text()), int(self.height.get_text())
+
+
 class FractalWindow(Gtk.ScrolledWindow):
     def __init__(self, f, compiler):
         super().__init__()

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -272,7 +272,9 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.create_toolbar()
         panes = Gtk.Paned(expand=True)
         self.vbox.add(panes)
-        self.create_status_bar()
+
+        self.statusbar = Gtk.ProgressBar(show_text=True)
+        self.vbox.pack_end(self.statusbar, False, True, 0)
 
         try:
             # try to make default image more interesting
@@ -334,10 +336,6 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         if is4dsensitive:
             self.four_d_sensitives.append(my_angle)
-
-    def create_status_bar(self):
-        self.bar = Gtk.ProgressBar(show_text=True)
-        self.vbox.pack_end(self.bar, False, True, 0)
 
     def create_resolution_menu(self):
         self.resolutions = [

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -139,21 +139,8 @@ class ApplicationDialogs:
 
     def get_save_hires_image_as_fs(self):
         if self.hires_image_fs is None:
-            self.hires_image_fs = utils.FileSaveChooser(
-                _("Save High Resolution Image"), self, image.file_matches())
-
-            table = Gtk.Grid(row_spacing=1, column_spacing=1)
-            table.width = Gtk.Entry(text="2048")
-            table.height = Gtk.Entry(text="1536")
-            table.attach(Gtk.Label(label=_("Width:")), 0, 0, 1, 1)
-            table.attach(Gtk.Label(label=_("Height:")), 0, 1, 1, 1)
-            table.attach(table.width, 1, 0, 1, 1)
-            table.attach(table.height, 1, 1, 1, 1)
-            self.hires_image_fs.set_extra_widget(table)
-
-            self.hires_image_fs.get_hires_dimensions = lambda: (
-                int(table.width.get_text()), int(table.height.get_text())
-            )
+            self.hires_image_fs = application_widgets.HiresImageSaveChooser(
+                self, image.file_matches())
 
         return self.hires_image_fs
 

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -197,10 +197,10 @@ class MainWindow(Actions, ApplicationWindow):
         self.nudge(0, 1, parameter.unpack())
 
     def progress_changed(self, f, progress):
-        self.bar.set_fraction(progress / 100.0)
+        self.statusbar.set_fraction(progress / 100.0)
 
     def stats_changed(self, f, stats):
-        self.bar.set_tooltip_text(stats.show())
+        self.statusbar.set_tooltip_text(stats.show())
 
     def status_changed(self, f, status):
         if status == 2:
@@ -218,7 +218,7 @@ class MainWindow(Actions, ApplicationWindow):
         else:
             text = STATUS[status]
 
-        self.bar.set_text(text)
+        self.statusbar.set_text(text)
 
     def save_hires_image(self, *args):
         """Add the current fractal to the render queue."""
@@ -283,7 +283,7 @@ class MainWindow(Actions, ApplicationWindow):
             self.fullscreen()
             self.set_show_menubar(False)
             self.toolbar.hide()
-            self.bar.hide()
+            self.statusbar.hide()
             self.fractalWindow.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.NEVER)
 
             display = self.get_display()
@@ -300,7 +300,7 @@ class MainWindow(Actions, ApplicationWindow):
                 Gtk.PolicyType.AUTOMATIC)
             self.set_show_menubar(True)
             self.toolbar.show()
-            self.bar.show()
+            self.statusbar.show()
             self.unfullscreen()
 
         self.fullscreen_action.set_state(GLib.Variant("b", to_full))
@@ -334,7 +334,7 @@ class MainWindow(Actions, ApplicationWindow):
     def on_angle_slightly_changed(self, widget, val):
         self.preview.set_param(widget.axis, val)
         angle_in_degrees = "%.2f" % (float(val) * 180.0 / math.pi)
-        self.bar.set_text(angle_in_degrees)
+        self.statusbar.set_text(angle_in_degrees)
         self.draw_preview()
 
     def on_angle_changed(self, widget, val):


### PR DESCRIPTION
A couple of tweaks:

* Create a HiresImageSaveChooser class to be consistent with all the other file choosers in ApplicationDialogs
* Rename ApplicationWindow.bar to statusbar, clarifying what it is and matching menubar and toolbar
