### PR TITLE
Align right settings location table labels, GTK 4 and Gio.resources_register()

### DIFF
--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -283,7 +283,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.add(self.vbox)
 
         self.create_toolbar()
-        panes = Gtk.Paned(expand=True)
+        panes = Gtk.Paned(vexpand=True)
         self.vbox.add(panes)
         self.create_status_bar()
 

--- a/fract4dgui/hig.py
+++ b/fract4dgui/hig.py
@@ -22,10 +22,10 @@ class Alert(Gtk.MessageDialog):
             message_type=type,
             title=title,
             text=primary_text,
+            secondary_text=secondary_text,
             buttons=buttontype)
 
         self.add_buttons(*buttons)
-        self.format_secondary_text(secondary_text)
 
         self.show_all()
 

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -30,7 +30,7 @@ class Application(Gtk.Application):
 
         resource = Gio.resource_load(
             fractconfig.T.find_resource("gnofract4d.gresource", ""))
-        Gio.Resource._register(resource)
+        Gio.resources_register(resource)
 
     def do_startup(self):
         Gtk.Application.do_startup(self)

--- a/fract4dgui/settings.py
+++ b/fract4dgui/settings.py
@@ -693,7 +693,12 @@ class SettingsPane(Gtk.Box):
         dialog.destroy()
 
     def create_param_entry(self, table, row, text, param):
-        label = Gtk.Label(label=text, use_underline=True, justify=Gtk.Justification.RIGHT)
+        label = Gtk.Label(
+            label=text,
+            halign=Gtk.Align.END,
+            justify=Gtk.Justification.RIGHT,
+            margin_end=5,
+            use_underline=True)
         table.attach(label, 0, row, 1, 1)
 
         entry = Gtk.Entry(activates_default=True, hexpand=True)


### PR DESCRIPTION
Three small fixes.

GTK 4 compatibility and Gio.resources_register() do not change the GUI.

The other commit is for the Fractal Settings, Location tab - the shorter labels and their colons were more centered than right aligned.