### PR TITLE
Use toolbar CSS

### DIFF
--- a/fract4dgui/angle.py
+++ b/fract4dgui/angle.py
@@ -17,7 +17,7 @@ class T(Gtk.DrawingArea):
     two_pi = 2.0 * math.pi
     ptr_radius = 4
 
-    def __init__(self, text, tip, axis):
+    def __init__(self, text, tip, axis, size):
         self.axis = axis
         self.radius = 0
         self.text = text
@@ -34,7 +34,8 @@ class T(Gtk.DrawingArea):
 
         self.adjustment.connect('value-changed', self.onAdjustmentValueChanged)
 
-        Gtk.DrawingArea.__init__(self, tooltip_text=tip, width_request=40, height_request=40)
+        Gtk.DrawingArea.__init__(
+            self, tooltip_text=tip, width_request=size, height_request=size)
 
         self.set_events(
             Gdk.EventMask.BUTTON_RELEASE_MASK |

--- a/fract4dgui/application_widgets.py
+++ b/fract4dgui/application_widgets.py
@@ -169,17 +169,17 @@ class FractalFilename:
 
 class Toolbar(Gtk.Box):
     def __init__(self):
-        super().__init__(margin=5, spacing=1)
+        super().__init__()
+        self.get_style_context().add_class("toolbar")
 
     @staticmethod
     def button_args(icon_name, tip_text, action):
-        icon = Gtk.Image(icon_name=icon_name, icon_size=Gtk.IconSize.LARGE_TOOLBAR, margin=5)
+        icon = Gtk.Image(icon_name=icon_name, icon_size=Gtk.IconSize.LARGE_TOOLBAR)
         return dict(
             action_name=action, image=icon, relief=Gtk.ReliefStyle.NONE, tooltip_text=tip_text)
 
     def add_space(self):
-        self.add(Gtk.Separator(
-            orientation=Gtk.Orientation.VERTICAL, margin_start=5, margin_end=5))
+        self.add(Gtk.Separator(orientation=Gtk.Orientation.VERTICAL))
 
     def add_button(self, icon_name, tip_text, action):
         self.add(Gtk.Button(**self.button_args(icon_name, tip_text, action)))

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -8,6 +8,8 @@ from fract4d import fractal, fractconfig, image
 from fract4d.options import VERSION
 from . import angle, application_widgets, fourway, gtkfractal, hig, settings, utils
 
+TOOLITEM_SIZE = 53
+
 
 class Actions:
     def get_toggle_actions(self):
@@ -252,7 +254,8 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
 
         self.filename = application_widgets.FractalFilename(self.f)
 
-        self.preview = gtkfractal.Preview(application.compiler, 48, 48)
+        self.preview = gtkfractal.Preview(
+            application.compiler, TOOLITEM_SIZE, TOOLITEM_SIZE)
         self.preview.widget.set_tooltip_text(_("Preview"))
 
         theme_provider = Gtk.CssProvider()
@@ -293,7 +296,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         panes.pack2(self.settingsPane, resize=False, shrink=False)
 
     def add_fourway(self, name, tip, axis, is4dsensitive):
-        my_fourway = fourway.T(name, tip, axis)
+        my_fourway = fourway.T(name, tip, axis, TOOLITEM_SIZE)
         self.toolbar.add(my_fourway)
 
         my_fourway.connect('value-slightly-changed', self.on_drag_fourway)
@@ -323,7 +326,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.toolbar.add(self.warpmenu)
 
     def add_angle(self, name, tip, axis, is4dsensitive):
-        my_angle = angle.T(name, tip, axis)
+        my_angle = angle.T(name, tip, axis, round(TOOLITEM_SIZE * 0.75))
         my_angle.connect('value-slightly-changed',
                          self.on_angle_slightly_changed)
         my_angle.connect('value-changed',

--- a/fract4dgui/fourway.py
+++ b/fract4dgui/fourway.py
@@ -13,14 +13,15 @@ class T(Gtk.DrawingArea):
             None, (GObject.TYPE_INT, GObject.TYPE_INT))
     }
 
-    def __init__(self, text, tip, axis=None):
+    def __init__(self, text, tip, axis=None, size=53):
         self.axis = axis
         self.button = 0
         self.radius = 0
         self.last_x = 0
         self.last_y = 0
         self.text = text
-        Gtk.DrawingArea.__init__(self, tooltip_text=tip, width_request=53, height_request=53)
+        Gtk.DrawingArea.__init__(
+            self, tooltip_text=tip, width_request=size, height_request=size)
 
         self.set_events(
             Gdk.EventMask.BUTTON_RELEASE_MASK |

--- a/fract4dgui/gnofract4d.css
+++ b/fract4dgui/gnofract4d.css
@@ -39,3 +39,21 @@ notebook grid {
 #weirdbox scale {
     padding: 2px;
 }
+
+/* toolbar class style exists in GTK 4 */
+
+.toolbar {
+    padding: 4px;
+}
+
+.toolbar button {
+    margin: 1px;
+}
+
+.toolbar button image {
+    margin: 5px;
+}
+
+.toolbar separator.vertical {
+    margin: 0 5px 0 5px;
+}

--- a/fract4dgui/tests/test_angle.py
+++ b/fract4dgui/tests/test_angle.py
@@ -11,14 +11,14 @@ from fract4dgui import angle
 
 class Test(unittest.TestCase):
     def testCreate(self):
-        a = angle.T("hello", "angle", 0)
+        a = angle.T("hello", "angle", 0, 40)
         self.assertTrue(a)
         self.assertEqual(a.adjustment.get_lower(), -math.pi)
         self.assertEqual(a.adjustment.get_upper(), math.pi)
         self.assertEqual(a.adjustment.get_value(), 0.0)
 
     def testAngles(self):
-        a = angle.T("foo", "angle", 0)
+        a = angle.T("foo", "angle", 0, 40)
 
         self.assertEqual(a.get_current_angle(), 0.0)
 
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
         self.assertEqual(a.get_current_angle(), math.pi)
 
     def testPointerCoords(self):
-        a = angle.T("foo", "angle", 0)
+        a = angle.T("foo", "angle", 0, 40)
 
         # 0 should point right
         self.assertNearlyEqual(
@@ -57,7 +57,7 @@ class Test(unittest.TestCase):
             (0, -(40 - angle.T.ptr_radius)))
 
     def testUpdateFromMouse(self):
-        a = angle.T("foo", "angle", 0)
+        a = angle.T("foo", "angle", 0, 40)
         a.update_from_mouse(100, 100)
 
     def assertNearlyEqual(self, a, b):


### PR DESCRIPTION
With a 1024x768 fractal I had a blank margin down the right of the application, changing to setting margin and padding for the toolbar in CSS fixed this for me. It is also what is recommended and available in GTK 4.

The Preview fractal has more space below than above, this can be seen on macOS:
https://user-images.githubusercontent.com/1893197/102902879-72023680-4467-11eb-9541-4be960fad93b.png

Increasing the size of the Preview to 53 pixels fixes this, make this one value used by all of the toolbar items. This is just a constant here, but could be the start of making it configurable in the future.
