### PR TITLE
Allow "Save changes" dialog to be closed by Escape

### DIFF
--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -141,7 +141,6 @@ class ApplicationDialogs:
         if self.hires_image_fs is None:
             self.hires_image_fs = application_widgets.HiresImageSaveChooser(
                 self, image.file_matches())
-
         return self.hires_image_fs
 
     def about(self, *args):
@@ -256,8 +255,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, ApplicationDialogs):
         self.preview.widget.set_tooltip_text(_("Preview"))
 
         theme_provider = Gtk.CssProvider()
-        css_file = "/io/github/fract4d/gnofract4d.css"
-        theme_provider.load_from_resource(css_file)
+        theme_provider.load_from_resource("/io/github/fract4d/gnofract4d.css")
         Gtk.StyleContext.add_provider_for_screen(
             Gdk.Screen.get_default(), theme_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 

--- a/fract4dgui/application_window.py
+++ b/fract4dgui/application_window.py
@@ -122,7 +122,7 @@ class ApplicationDialogs:
     def get_open_fs(self, compiler):
         if self.open_fs is None:
             self.open_fs = application_widgets.Fract4dOpenChooser(
-                self, gtkfractal.Preview(self.compiler))
+                self, gtkfractal.Preview(compiler))
         return self.open_fs
 
     def get_save_as_fs(self):

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -526,9 +526,7 @@ class MainWindow(Actions, ApplicationWindow):
 
     def report_bug(self, *args):
         url = "https://github.com/fract4d/gnofract4d/issues"
-        utils.launch_browser(
-            url,
-            self)
+        utils.launch_browser(url, self)
 
     def open(self, *args):
         """Open a parameter or formula file."""

--- a/fract4dgui/main_window.py
+++ b/fract4dgui/main_window.py
@@ -582,7 +582,8 @@ class MainWindow(Actions, ApplicationWindow):
             d.destroy()
             if response == Gtk.ResponseType.ACCEPT:
                 self.save(None)
-            elif response == Gtk.ResponseType.CANCEL:
+            elif response == Gtk.ResponseType.CANCEL \
+                    or response == Gtk.ResponseType.DELETE_EVENT:
                 return False
             elif response == hig.SaveConfirmationAlert.NOSAVE:
                 break

--- a/fract4dgui/tests/test_main_window.py
+++ b/fract4dgui/tests/test_main_window.py
@@ -172,7 +172,7 @@ class Test(testgui.TestCase):
         self.mw.get_save_as_fs()
         self.mw.get_save_image_as_fs()
         self.mw.get_save_hires_image_as_fs()
-        self.mw.get_open_fs(fc.Compiler(Test.userConfig))
+        self.mw.get_open_fs(self.g_comp)
 
     def testExplorer(self):
         self.mw.load("testdata/nexus.fct")


### PR DESCRIPTION
One fix for pressing Escape causes the "Save changes" exit dialog to be reshown.

Plus some final tidying up that is the end of this sequence of changes from me.
