### PR TITLE
Pin pylint to version 2.6.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ passenv = DISPLAY XAUTHORITY HOME
 # pytest is imported by tests
 [testenv:pylint]
 deps =
-    pylint
+    pylint==2.6.2
     pytest
 
 commands = {toxinidir}/bin/pylint.sh


### PR DESCRIPTION
Avoid false positives with 2.7.

2.7.0
E1101: Instance of 'OverloadList' has no 'ret' member (no-member)
https://github.com/fract4d/gnofract4d/runs/1955404235#step:9:15

2.7.2
E1126: Sequence index is not an int, slice, or instance with `__index__` (invalid-sequence-index)
https://github.com/PyCQA/pylint/issues/4083