### PR TITLE
Make configuration file keys case sensitive

### DIFF
--- a/fract4d/fractconfig.py
+++ b/fract4d/fractconfig.py
@@ -165,6 +165,10 @@ class T(configparser.ConfigParser):
         # appears to work for most unixes
         return "-fPIC -DPIC -O2 -shared -ffast-math"
 
+    def optionxform(self, option):
+        # make keys case-sensitive because some are file paths
+        return str(option)
+
     def set(self, section, key, val):
         if self.has_section(section) and \
            self.has_option(section, key) and \


### PR DESCRIPTION
Fixes problems with file paths caused by:
3e3509e ("Fix duplicating formula_paths in user configuration (#217)", 2021-02-04)

---

I think this is OK because we don't expect the user to directly edit this file.

Fixes #239.
