### PR TITLE
Fix bdist_rpm after recent changes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
+include bin/*
 include doc/gnofract4d.1
 include formulas/fractint-builtin.frm
 include formulas/fractint-g4.frm
@@ -14,9 +15,10 @@ include fract4d/c/fract4dc/*.h
 include fract4d/c/model/*.h
 include fract4d/tests/*.py
 include fract4d_compiler/tests/*.py
+include fract4dgui/builder/*.ui
 include fract4dgui/tests/*.py
-include fract4dgui/ui.xml
 include fract4dgui/gnofract4d.css
+include fract4dgui/gnofract4d.gresource.xml
 include gnofract4d
 include gnofract4d-mime.xml
 include gnofract4d.desktop

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,3 @@
 group=X11/Applications/Graphics
 release=1
 packager=Edwin Young (edwin@bathysphere.org)
-doc-files=README.md COPYING
-


### PR DESCRIPTION
Fails because COPYING cannot be found and does not include new
resources.
