### PR TITLE
Ensure testGetCoolorUrl() closes test.ase

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   notify:
     # Ensure both Mac and Linux results are uploaded
-    after_n_builds: 6
+    after_n_builds: 5
 
 coverage:
   status:

--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-20.04]
         python: ["3.8", "3.9", "3.10"]
         toxenv: [py]
-        # Ensure ../codecov.yml uploads after all jobs
+        # Ensure ../codecov.yml uploads after all py jobs
         include:
           - os: macos-10.15
             python: "3.7"

--- a/fract4d/tests/test_gradient.py
+++ b/fract4d/tests/test_gradient.py
@@ -702,9 +702,8 @@ opacity:
 
     def testGetCoolorUrl(self):
         g = gradient.Gradient()
-        f = open("testdata/test.ase", "rb")
-
-        g.load_ase(f)
+        with open("testdata/test.ase", "rb") as f:
+            g.load_ase(f)
         self.assertEqual(5, len(g.segments))
         self.assertEqual(
             [0x94 / 255.0, 0xAE / 255.0, 0x89 / 255.0, 1.0],


### PR DESCRIPTION
Fixes:
```py
fract4d/tests/test_gradient.py::Test::testGetCoolorUrl
  /usr/lib/python3.10/unittest/case.py:549: ResourceWarning: unclosed file <_io.BufferedReader name='testdata/test.ase'>
    method()
```