### PR TITLE
Testing Updates

### DIFF
--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         toxenv: [py]
         # Ensure ../codecov.yml uploads after all py jobs
         include:

--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -17,7 +17,7 @@ jobs:
         toxenv: [py]
         # Ensure ../codecov.yml uploads after all py jobs
         include:
-          - os: macos-10.15
+          - os: macos-11
             python: "3.7"
             toxenv: py
           - os: ubuntu-18.04

--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -33,7 +33,7 @@ jobs:
       PYTHON: ${{ matrix.python }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install macOS packages
         if: ${{ runner.os == 'macOS' }}
         run: brew install gtk+3 pygobject3
@@ -48,7 +48,7 @@ jobs:
         # libxml2-utils provides xmllint for xml-stripblanks in gresource.xml
         run: sudo apt install gir1.2-gtk-3.0 gvfs libgirepository1.0-dev libxml2-utils xvfb
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other PyPI packages
@@ -63,7 +63,7 @@ jobs:
         run: xvfb-run --auto-servernum tox -e ${{ matrix.toxenv }}
       - name: Upload coverage to Codecov
         if: ${{ matrix.toxenv == 'py' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
           env_vars: OS,PYTHON

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7,8}
+envlist = py3{6,7,8,9,10,11}
 
 # system PyGObject is not used; pulls in Pycairo
 [testenv]


### PR DESCRIPTION
Test with Python 3.11

GitHub Actions have deprecated Node 12 and macOS 10

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

