### PR TITLE
Fix tests failing with pytest due to missing _()

### DIFF
--- a/fract4dgui/tests/test_autozoom.py
+++ b/fract4dgui/tests/test_autozoom.py
@@ -9,6 +9,7 @@ from fract4dgui import autozoom, gtkfractal
 
 class Test(testgui.TestCase):
     def setUp(self):
+        super().setUp()
         self.f = gtkfractal.T(Test.g_comp)
         self.mw = Gtk.Window()
 

--- a/fract4dgui/tests/test_browser.py
+++ b/fract4dgui/tests/test_browser.py
@@ -8,6 +8,7 @@ from fract4dgui import browser
 
 class Test(testgui.TestCase):
     def setUp(self):
+        super().setUp()
         self.f = fractal.T(Test.g_comp, self)
 
     def tearDown(self):

--- a/fract4dgui/tests/test_director.py
+++ b/fract4dgui/tests/test_director.py
@@ -26,6 +26,7 @@ class Window(Gtk.Window):
 
 class Test(testgui.TestCase):
     def setUp(self):
+        super().setUp()
         # ensure any dialog boxes are dismissed without human interaction
         hig.timeout = 250
 

--- a/fract4dgui/tests/test_director_dialogs.py
+++ b/fract4dgui/tests/test_director_dialogs.py
@@ -12,6 +12,7 @@ from fract4d import fractal, animation
 
 class Test(testgui.TestCase):
     def setUp(self):
+        super().setUp()
         f = fractal.T(Test.g_comp)
         self.test_animation = animation.T(f.compiler, Test.userConfig)
 

--- a/fract4dgui/tests/test_hig.py
+++ b/fract4dgui/tests/test_hig.py
@@ -26,6 +26,8 @@ class MockDialog(Gtk.MessageDialog, hig.MessagePopper):
 
 class Test(unittest.TestCase):
     def setUp(self):
+        os.environ.setdefault('LANG', 'en')
+        gettext.install('gnofract4d')
         hig.timeout = 0
 
     def testCreate(self):

--- a/fract4dgui/tests/test_main_window.py
+++ b/fract4dgui/tests/test_main_window.py
@@ -64,6 +64,7 @@ class TestApplication(testgui.TestCase):
 
 class Test(testgui.TestCase):
     def setUp(self):
+        super().setUp()
         self.mw = WrapMainWindow(Test.userConfig)
         self.assertEqual(self.mw.filename.filename, None, "shouldn't have a filename")
 

--- a/fract4dgui/tests/test_painter.py
+++ b/fract4dgui/tests/test_painter.py
@@ -14,6 +14,7 @@ class FakeEvent:
 
 class Test(testgui.TestCase):
     def setUp(self):
+        super().setUp()
         parent = Gtk.Window()
         self.f = parent.f = gtkfractal.T(Test.g_comp)
         self.settings = painter.PainterDialog(parent)

--- a/fract4dgui/tests/test_settings.py
+++ b/fract4dgui/tests/test_settings.py
@@ -10,6 +10,7 @@ from fract4dgui import gtkfractal, settings
 
 class Test(testgui.TestCase):
     def setUp(self):
+        super().setUp()
         self.f = gtkfractal.T(Test.g_comp)
         self.settings = settings.SettingsPane(None, self.f)
 

--- a/fract4dgui/tests/testgui.py
+++ b/fract4dgui/tests/testgui.py
@@ -3,13 +3,11 @@
 from fract4d import fractconfig
 from fract4d_compiler import fc
 import gi
-import os.path
+import os
 import tempfile
 import unittest
 
 import gettext
-os.environ.setdefault('LANG', 'en')
-gettext.install('gnofract4d')
 
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
@@ -38,3 +36,7 @@ class TestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.tmpdir.cleanup()
+
+    def setUp(self):
+        os.environ.setdefault('LANG', 'en')
+        gettext.install('gnofract4d')


### PR DESCRIPTION
TypeError: 'NoneType' object is not callable

---

Something changed when using pytest on its own - I've seen this on other projects. You now have to have the gettext `_()` alias installed.
