### PR TITLE
Respect environment CFLAGS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ if not shutil.which("glib-compile-resources"):
 # by default python uses all the args which were used to compile it. But Python is C and some
 # extension files are C++, resulting in annoying '-Wstrict-prototypes is not supported' messages.
 # tweak the cflags to override
-os.environ["CFLAGS"] = sysconfig.get_config_var(
-    "CFLAGS").replace("-Wstrict-prototypes", "")
-os.environ["OPT"] = sysconfig.get_config_var(
-    "OPT").replace("-Wstrict-prototypes", "")
+os.environ["CFLAGS"] = os.environ.get("CFLAGS", "").replace("-Wstrict-prototypes", "")
 
 # Extensions need to link against appropriate libs
 # We use pkg-config to find the appropriate set of includes and libs
@@ -132,7 +129,7 @@ if _DEBUG:
         # ('DEBUG_PIXEL',1), # debug spew for array handling
         # ('EXPERIMENTAL_OPTIMIZATIONS',1), # enables some experimental optimizations
     ]
-else:
+elif not os.environ["CFLAGS"]:
     extra_compile_args += ["-DNDEBUG", "-O3"]
 
 module_fract4dc = Extension(


### PR DESCRIPTION
[1] indirectly removed -Wstrict-prototypes by overwriting the environment CFLAGS with sysconfig.get_config_var("CFLAGS"), which is passed to the compiler anyway [2].

sysconfig.get_config_var("OPT") is included in
sysconfig.get_config_var("CFLAGS") [3].

Don't pass -O3 if CFLAGS is set because only the last -O option is used [4]. -DNDEBUG is typically present in sysconfig.get_config_var("CFLAGS").

[1]
426676c ("silenced annoying -Wstrict-prototypes warning", 2015-06-07)

[2]
https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#compiler-and-linker-options

[3]
https://github.com/python/cpython/blob/351842b46a7cb3c3f23b200d532cf29e4557ad4b/Makefile.pre.in#L101

[4]
https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html