### PR TITLE
Fix building when pytest is not installed

### DIFF
--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -17,7 +17,7 @@ jobs:
         toxenv: [py]
         # Ensure ../codecov.yml uploads after all py jobs
         include:
-          - os: macos-11
+          - os: macos-12
             python: "3.7"
             toxenv: py
 

--- a/meson.build
+++ b/meson.build
@@ -144,14 +144,17 @@ custom_target('cp_confdata',
     build_by_default: true,
 )
 
-test('testing',
-    find_program('pytest', required: false),
-    args: ['-v',
-        'fract4d',
-        'fract4dgui',
-        'fract4d_compiler',
-        'test.py',
-    ],
-    timeout: 60,
-    workdir: meson.project_source_root(),
-)
+pytest = find_program('pytest', required: false)
+if pytest.found()
+    test('testing',
+        pytest,
+        args: [
+            'fract4d',
+            'fract4dgui',
+            'fract4d_compiler',
+            'test.py',
+        ],
+        timeout: 60,
+        workdir: meson.project_source_root(),
+    )
+endif


### PR DESCRIPTION
Closes #257.

I've also raised the macOS version used in the workflow - gtk4 isn't available for macOS 11 from Homebrew, slowing the check.
 