### PR TITLE
Raise minimum Python version to 3.9, start testing 3.13

### DIFF
--- a/.github/workflows/test-gnofract4d.yml
+++ b/.github/workflows/test-gnofract4d.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.10", "3.11", "3.12", "3.13-dev"]
         toxenv: [py]
         # Ensure ../codecov.yml uploads after all py jobs
         include:
           - os: macos-12
-            python: "3.7"
+            python: "3.9"
             toxenv: py
 
     env:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requirements
 
 Gnofract 4D requires these packages to run:
 
-- Python version 3.6 or higher
+- Python version 3.9 or higher
 - GTK version 4.6 or higher
 - PyGObject version 3.29.2 or higher to access GTK from Python
 - A C compiler (used at runtime to compile your fractal formulas)

--- a/fract4d/c/fract4dmodule.cpp
+++ b/fract4d/c/fract4dmodule.cpp
@@ -651,9 +651,6 @@ PyInit_fract4dc(void)
         return NULL;
     }
 
-    // todo: check this https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads
-    PyEval_InitThreads();
-
     /* expose some constants */
     PyModule_AddIntConstant(pymod, "CALC_DONE", GF4D_FRACTAL_DONE);
     PyModule_AddIntConstant(pymod, "CALC_CALCULATING", GF4D_FRACTAL_CALCULATING);

--- a/meson.build
+++ b/meson.build
@@ -22,8 +22,8 @@ pymod = import('python')
 py = pymod.find_installation()
 
 py_version = py.language_version()
-if py_version.version_compare('< 3.6')
-    error('Sorry, you need Python 3.6 or higher to run Gnofract 4D.'
+if py_version.version_compare('< 3.9')
+    error('Sorry, you need Python 3.9 or higher to run Gnofract 4D.'
           + ' You have version ' + py_version + '. Please upgrade.')
 endif
 


### PR DESCRIPTION
PyEval_InitThreads() does nothing in Python 3.9-12 and is dropped in 3.13.

---

Python 3.8 does have a few months left but with the change to GTK 4 we dropped compatibility with Ubuntu 20.04 anyway.
